### PR TITLE
Fixed operator precedence issues.

### DIFF
--- a/CoreParse/Grammar/CPGrammar.m
+++ b/CoreParse/Grammar/CPGrammar.m
@@ -444,7 +444,7 @@
 
 - (NSUInteger)hash
 {
-    return [[self start] hash] << 16 + [[self rules] hash];
+    return ([[self start] hash] << 16) + [[self rules] hash];
 }
 
 - (BOOL)isGrammar

--- a/CoreParse/Grammar/CPRHSItem.m
+++ b/CoreParse/Grammar/CPRHSItem.m
@@ -23,7 +23,7 @@
 
 - (NSUInteger)hash
 {
-    return [[self alternatives] hash] << 2 + ([self repeats] ? 0x2 : 0x0) + ([self mayNotExist] ? 0x1 : 0x0);
+    return ([[self alternatives] hash] << 2) + ([self repeats] ? 0x2 : 0x0) + ([self mayNotExist] ? 0x1 : 0x0);
 }
 
 - (BOOL)isRHSItem

--- a/CoreParse/Grammar/CPRule.m
+++ b/CoreParse/Grammar/CPRule.m
@@ -134,7 +134,7 @@
 
 - (NSUInteger)hash
 {
-    return [name hash] << 16 + [self tag] ;
+    return ([name hash] << 16) + [self tag] ;
 }
 
 - (BOOL)isRule

--- a/CoreParse/Parsers/CPShiftReduceParsers/CPLR1Item.m
+++ b/CoreParse/Parsers/CPShiftReduceParsers/CPLR1Item.m
@@ -66,7 +66,7 @@
 
 - (NSUInteger)hash
 {
-    return [[self rule] hash] << 16 + [terminal hash] + [self position];
+    return ([[self rule] hash] << 16) + [terminal hash] + [self position];
 }
 
 - (NSString *)description


### PR DESCRIPTION
Hi Tom,

I found a possible issue in the way you calculate your hashes in CoreParse: the + operator is evaluated before <<. I fixed it by adding parentheses where needed.

Regards,
Frank
