### PR TITLE
Using ARC

### DIFF
--- a/CoreParse.xcodeproj/project.pbxproj
+++ b/CoreParse.xcodeproj/project.pbxproj
@@ -78,7 +78,6 @@
 		1F893A1F14DEEBFC00316FF7 /* CPRecoveryAction.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F893A1D14DEEBFC00316FF7 /* CPRecoveryAction.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1F893A2014DEEBFC00316FF7 /* CPRecoveryAction.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F893A1E14DEEBFC00316FF7 /* CPRecoveryAction.m */; };
 		1F893A2314DEF40D00316FF7 /* CPTestErrorEvaluatorDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F893A2114DEF40D00316FF7 /* CPTestErrorEvaluatorDelegate.h */; };
-		1F893A2414DEF40D00316FF7 /* CPTestErrorEvaluatorDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F893A2214DEF40D00316FF7 /* CPTestErrorEvaluatorDelegate.m */; };
 		1F928180145C11050033BC34 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FE77D551375AE6F00879A41 /* Foundation.framework */; };
 		1F92818E145C11050033BC34 /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F92818D145C11050033BC34 /* SenTestingKit.framework */; };
 		1F928190145C11050033BC34 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F92818F145C11050033BC34 /* UIKit.framework */; };
@@ -137,7 +136,6 @@
 		1FA68DA014DE98C4005519B9 /* CPErrorToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FA68D9E14DE98C4005519B9 /* CPErrorToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1FA68DA114DE98C4005519B9 /* CPErrorToken.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FA68D9F14DE98C4005519B9 /* CPErrorToken.m */; };
 		1FA68DA514DE9D3D005519B9 /* CPTestErrorHandlingDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FA68DA314DE9D3D005519B9 /* CPTestErrorHandlingDelegate.h */; };
-		1FA68DA614DE9D3D005519B9 /* CPTestErrorHandlingDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FA68DA414DE9D3D005519B9 /* CPTestErrorHandlingDelegate.m */; };
 		1FA798201567DC0E003AC8AE /* Expression.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F9F83A013B731F3006E939D /* Expression.m */; };
 		1FA798221567DC11003AC8AE /* Term.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F9F83A513B732AC006E939D /* Term.m */; };
 		1FA798231567DC49003AC8AE /* CPTestEvaluatorDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FB3EB23132BA02C00ACC453 /* CPTestEvaluatorDelegate.m */; };
@@ -148,7 +146,6 @@
 		1FA866B715DFAEBC005350EE /* CPRule+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FA866B515DFAEBB005350EE /* CPRule+Internal.h */; };
 		1FA866C015E18F68005350EE /* CPRHSItem+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FA866BE15E18F67005350EE /* CPRHSItem+Private.h */; };
 		1FB3EB24132BA02C00ACC453 /* CPTestEvaluatorDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FB3EB22132BA02C00ACC453 /* CPTestEvaluatorDelegate.h */; };
-		1FB3EB25132BA02C00ACC453 /* CPTestEvaluatorDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FB3EB23132BA02C00ACC453 /* CPTestEvaluatorDelegate.m */; };
 		1FB3EB2C132BB2F200ACC453 /* CPLR1Parser.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FB3EB2A132BB2E600ACC453 /* CPLR1Parser.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1FB3EB2D132BB2F200ACC453 /* CPLR1Parser.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FB3EB2B132BB2ED00ACC453 /* CPLR1Parser.m */; };
 		1FB3EB30132BB31700ACC453 /* CPLR1Item.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FB3EB2E132BB30300ACC453 /* CPLR1Item.h */; };
@@ -157,9 +154,7 @@
 		1FB3EB3B132D096900ACC453 /* CPGrammarSymbol.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FB3EB39132D096800ACC453 /* CPGrammarSymbol.m */; };
 		1FB719A414E00FE300BD033C /* CPErrorToken.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FA68D9F14DE98C4005519B9 /* CPErrorToken.m */; };
 		1FB81322132FEDAF0095982D /* CPTestWhiteSpaceIgnoringDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FB81320132FEDAF0095982D /* CPTestWhiteSpaceIgnoringDelegate.h */; };
-		1FB81323132FEDAF0095982D /* CPTestWhiteSpaceIgnoringDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FB81321132FEDAF0095982D /* CPTestWhiteSpaceIgnoringDelegate.m */; };
 		1FB81326132FF16E0095982D /* CPTestMapCSSTokenisingDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FB81324132FF16E0095982D /* CPTestMapCSSTokenisingDelegate.h */; };
-		1FB81327132FF16E0095982D /* CPTestMapCSSTokenisingDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FB81325132FF16E0095982D /* CPTestMapCSSTokenisingDelegate.m */; };
 		1FC00D5014544EDC00DC8D35 /* CPRHSItemResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FC00D4E14544EDC00DC8D35 /* CPRHSItemResult.h */; };
 		1FC00D5114544EDC00DC8D35 /* CPRHSItemResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FC00D4F14544EDC00DC8D35 /* CPRHSItemResult.m */; };
 		1FC1827D139ADC800027F597 /* CPGrammarPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FC1827B139ADC800027F597 /* CPGrammarPrivate.h */; };
@@ -169,6 +164,49 @@
 		1FC18287139BA47D0027F597 /* CoreParse-template.md in Resources */ = {isa = PBXBuildFile; fileRef = 1FC18286139BA47D0027F597 /* CoreParse-template.md */; };
 		DA2B1DF81566B704002FDBD7 /* CPSTAssertionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DA2B1DF71566B704002FDBD7 /* CPSTAssertionsTests.m */; };
 		DA2B1DF91566B704002FDBD7 /* CPSTAssertionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DA2B1DF71566B704002FDBD7 /* CPSTAssertionsTests.m */; };
+		EA457DDD1885C2D4004D8147 /* CPTokeniser.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F0E8937130463E900537D04 /* CPTokeniser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EA457DDE1885C2DB004D8147 /* CPTokenStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F0E8941130466CF00537D04 /* CPTokenStream.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EA457DDF1885C2DF004D8147 /* CPTokenRecogniser.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F4683881306AA8500407491 /* CPTokenRecogniser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EA457DE01885C2E2004D8147 /* CPKeywordRecogniser.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F4683861306AA8500407491 /* CPKeywordRecogniser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EA457DE11885C2E4004D8147 /* CPNumberRecogniser.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F4683941306BF6200407491 /* CPNumberRecogniser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EA457DE21885C2EA004D8147 /* CPWhiteSpaceRecogniser.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F4683A01306D66300407491 /* CPWhiteSpaceRecogniser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EA457DE31885C2ED004D8147 /* CPIdentifierRecogniser.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F1DFCDF1306E3C300B22855 /* CPIdentifierRecogniser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EA457DE41885C2EF004D8147 /* CPQuotedRecogniser.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F1DFCF11307D2C500B22855 /* CPQuotedRecogniser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EA457DE51885C2F3004D8147 /* CPToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F0E894A1306795500537D04 /* CPToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EA457DE61885C2F5004D8147 /* CPEOFToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F4683901306B71C00407491 /* CPEOFToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EA457DE71885C2F7004D8147 /* CPErrorToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FA68D9E14DE98C4005519B9 /* CPErrorToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EA457DE81885C2F9004D8147 /* CPKeywordToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F46838C1306B45400407491 /* CPKeywordToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EA457DE91885C2FC004D8147 /* CPNumberToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F4683981306C22800407491 /* CPNumberToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EA457DEA1885C300004D8147 /* CPWhiteSpaceToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F4683A41306D7CB00407491 /* CPWhiteSpaceToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EA457DEB1885C302004D8147 /* CPIdentifierToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F1DFCE31306E8E800B22855 /* CPIdentifierToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EA457DEC1885C305004D8147 /* CPQuotedToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F1DFCED1307D18900B22855 /* CPQuotedToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EA457DED1885C319004D8147 /* CPGrammar.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F50A93C1308604A00C50D7D /* CPGrammar.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EA457DEE1885C31E004D8147 /* CPRule.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F530B8F1322813E00F52EB5 /* CPRule.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EA457DEF1885C325004D8147 /* CPSyntaxTree.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F530B8513216A1A00F52EB5 /* CPSyntaxTree.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EA457DF01885C329004D8147 /* CPParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F530B7C13215A6F00F52EB5 /* CPParser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EA457DF11885C33F004D8147 /* CPLALR1Parser.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F6D448E1348CC9500E982C7 /* CPLALR1Parser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EA457DF21885C342004D8147 /* CPLR1Parser.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FB3EB2A132BB2E600ACC453 /* CPLR1Parser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EA457DF31885C351004D8147 /* CPSLRParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F3881FF1323DB49000C8876 /* CPSLRParser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EA457DF41885C386004D8147 /* CPShiftReduceParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F3881DA1322ACE7000C8876 /* CPShiftReduceParser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EA457DF51885C38E004D8147 /* CPRecoveryAction.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F893A1D14DEEBFC00316FF7 /* CPRecoveryAction.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EA457DF61885C3B2004D8147 /* CPGrammarSymbol.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FB3EB38132D096700ACC453 /* CPGrammarSymbol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EA457DF71885C3B8004D8147 /* CPJSONParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F45A2E213422E1300092D78 /* CPJSONParser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EA457DF81885C3D0004D8147 /* CoreParse.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F0E8934130463D000537D04 /* CoreParse.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EA457DF91885C48B004D8147 /* CPGrammarPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FC1827B139ADC800027F597 /* CPGrammarPrivate.h */; };
+		EA457DFA1885C491004D8147 /* CPGrammarInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FC18280139AE3800027F597 /* CPGrammarInternal.h */; };
+		EA457DFB1885C497004D8147 /* CPRule+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FA866B515DFAEBB005350EE /* CPRule+Internal.h */; };
+		EA457DFC1885C49E004D8147 /* CPRHSItem+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FA866BE15E18F67005350EE /* CPRHSItem+Private.h */; };
+		EA457DFD1885C4A3004D8147 /* CPRHSItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F9F83AA13B7CAB9006E939D /* CPRHSItem.h */; };
+		EA457DFE1885C4A7004D8147 /* CPRHSItemResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FC00D4E14544EDC00DC8D35 /* CPRHSItemResult.h */; };
+		EA457DFF1885C4AF004D8147 /* CPShiftReduceAction.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F3881DF1322ADC9000C8876 /* CPShiftReduceAction.h */; };
+		EA457E001885C4B1004D8147 /* CPShiftReduceState.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F3881E31322AEE8000C8876 /* CPShiftReduceState.h */; };
+		EA457E011885C4B6004D8147 /* CPShiftReduceActionTable.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F3881EB1322B669000C8876 /* CPShiftReduceActionTable.h */; };
+		EA457E021885C4B9004D8147 /* CPShiftReduceGotoTable.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F3881EF1322B69E000C8876 /* CPShiftReduceGotoTable.h */; };
+		EA457E031885C4BD004D8147 /* CPItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F3882071323F75E000C8876 /* CPItem.h */; };
+		EA457E041885C4C0004D8147 /* CPLR1Item.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FB3EB2E132BB30300ACC453 /* CPLR1Item.h */; };
+		EA457E051885C4C4004D8147 /* CPShiftReduceParserProtectedMethods.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F3882031323DDD6000C8876 /* CPShiftReduceParserProtectedMethods.h */; };
+		EA457E061885C4DA004D8147 /* NSSetFunctional.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F38820B132432A1000C8876 /* NSSetFunctional.h */; };
+		EA457E071885C4DE004D8147 /* NSArray+Functional.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FA6430515E2C5130004FCD3 /* NSArray+Functional.h */; };
 		EA5FF42E1884CC6600BEEF03 /* CPTestErrorEvaluatorDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F893A2214DEF40D00316FF7 /* CPTestErrorEvaluatorDelegate.m */; };
 		EA5FF42F1884CC7100BEEF03 /* CPTestErrorHandlingDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FA68DA414DE9D3D005519B9 /* CPTestErrorHandlingDelegate.m */; };
 		EA5FF4301884FFDC00BEEF03 /* Expression2.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FA4386C162F515C00B92704 /* Expression2.m */; };
@@ -692,6 +730,49 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EA457DF81885C3D0004D8147 /* CoreParse.h in Headers */,
+				EA457DDD1885C2D4004D8147 /* CPTokeniser.h in Headers */,
+				EA457E041885C4C0004D8147 /* CPLR1Item.h in Headers */,
+				EA457E051885C4C4004D8147 /* CPShiftReduceParserProtectedMethods.h in Headers */,
+				EA457DDE1885C2DB004D8147 /* CPTokenStream.h in Headers */,
+				EA457DDF1885C2DF004D8147 /* CPTokenRecogniser.h in Headers */,
+				EA457DFA1885C491004D8147 /* CPGrammarInternal.h in Headers */,
+				EA457DE01885C2E2004D8147 /* CPKeywordRecogniser.h in Headers */,
+				EA457DFF1885C4AF004D8147 /* CPShiftReduceAction.h in Headers */,
+				EA457DE11885C2E4004D8147 /* CPNumberRecogniser.h in Headers */,
+				EA457E031885C4BD004D8147 /* CPItem.h in Headers */,
+				EA457DE21885C2EA004D8147 /* CPWhiteSpaceRecogniser.h in Headers */,
+				EA457DE31885C2ED004D8147 /* CPIdentifierRecogniser.h in Headers */,
+				EA457E021885C4B9004D8147 /* CPShiftReduceGotoTable.h in Headers */,
+				EA457DE41885C2EF004D8147 /* CPQuotedRecogniser.h in Headers */,
+				EA457DE51885C2F3004D8147 /* CPToken.h in Headers */,
+				EA457DE61885C2F5004D8147 /* CPEOFToken.h in Headers */,
+				EA457DE71885C2F7004D8147 /* CPErrorToken.h in Headers */,
+				EA457DE81885C2F9004D8147 /* CPKeywordToken.h in Headers */,
+				EA457DE91885C2FC004D8147 /* CPNumberToken.h in Headers */,
+				EA457DEA1885C300004D8147 /* CPWhiteSpaceToken.h in Headers */,
+				EA457DEB1885C302004D8147 /* CPIdentifierToken.h in Headers */,
+				EA457E011885C4B6004D8147 /* CPShiftReduceActionTable.h in Headers */,
+				EA457DFD1885C4A3004D8147 /* CPRHSItem.h in Headers */,
+				EA457DFB1885C497004D8147 /* CPRule+Internal.h in Headers */,
+				EA457E061885C4DA004D8147 /* NSSetFunctional.h in Headers */,
+				EA457E001885C4B1004D8147 /* CPShiftReduceState.h in Headers */,
+				EA457DEC1885C305004D8147 /* CPQuotedToken.h in Headers */,
+				EA457DED1885C319004D8147 /* CPGrammar.h in Headers */,
+				EA457DEE1885C31E004D8147 /* CPRule.h in Headers */,
+				EA457DEF1885C325004D8147 /* CPSyntaxTree.h in Headers */,
+				EA457DF01885C329004D8147 /* CPParser.h in Headers */,
+				EA457DF11885C33F004D8147 /* CPLALR1Parser.h in Headers */,
+				EA457DF21885C342004D8147 /* CPLR1Parser.h in Headers */,
+				EA457DF31885C351004D8147 /* CPSLRParser.h in Headers */,
+				EA457DF41885C386004D8147 /* CPShiftReduceParser.h in Headers */,
+				EA457DF51885C38E004D8147 /* CPRecoveryAction.h in Headers */,
+				EA457DFE1885C4A7004D8147 /* CPRHSItemResult.h in Headers */,
+				EA457E071885C4DE004D8147 /* NSArray+Functional.h in Headers */,
+				EA457DF61885C3B2004D8147 /* CPGrammarSymbol.h in Headers */,
+				EA457DF71885C3B8004D8147 /* CPJSONParser.h in Headers */,
+				EA457DFC1885C49E004D8147 /* CPRHSItem+Private.h in Headers */,
+				EA457DF91885C48B004D8147 /* CPGrammarPrivate.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -918,12 +999,9 @@
 				1F3882021323DB4A000C8876 /* CPSLRParser.m in Sources */,
 				1F38820A1323F760000C8876 /* CPItem.m in Sources */,
 				1F38820E132432B2000C8876 /* NSSetFunctional.m in Sources */,
-				1FB3EB25132BA02C00ACC453 /* CPTestEvaluatorDelegate.m in Sources */,
 				1FB3EB2D132BB2F200ACC453 /* CPLR1Parser.m in Sources */,
 				1FB3EB31132BB31700ACC453 /* CPLR1Item.m in Sources */,
 				1FB3EB3B132D096900ACC453 /* CPGrammarSymbol.m in Sources */,
-				1FB81323132FEDAF0095982D /* CPTestWhiteSpaceIgnoringDelegate.m in Sources */,
-				1FB81327132FF16E0095982D /* CPTestMapCSSTokenisingDelegate.m in Sources */,
 				1F45A2E513422E1300092D78 /* CPJSONParser.m in Sources */,
 				1F6D44911348CC9600E982C7 /* CPLALR1Parser.m in Sources */,
 				1FC1827E139ADC800027F597 /* CPGrammarPrivate.m in Sources */,
@@ -931,9 +1009,7 @@
 				1F9F83AD13B7CABA006E939D /* CPRHSItem.m in Sources */,
 				1FC00D5114544EDC00DC8D35 /* CPRHSItemResult.m in Sources */,
 				1FA68DA114DE98C4005519B9 /* CPErrorToken.m in Sources */,
-				1FA68DA614DE9D3D005519B9 /* CPTestErrorHandlingDelegate.m in Sources */,
 				1F893A2014DEEBFC00316FF7 /* CPRecoveryAction.m in Sources */,
-				1F893A2414DEF40D00316FF7 /* CPTestErrorEvaluatorDelegate.m in Sources */,
 				1FA6430815E2C5130004FCD3 /* NSArray+Functional.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1059,8 +1135,9 @@
 		1F0E891B130462F300537D04 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -1100,8 +1177,9 @@
 		1F0E891C130462F300537D04 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -1140,6 +1218,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -1166,6 +1246,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				INFOPLIST_FILE = "CoreParse/CoreParse-Info.plist";
 				INSTALL_PATH = "@rpath";
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				OTHER_CFLAGS = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_AFTER_BUILD = YES;
@@ -1177,6 +1258,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1203,6 +1286,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				INFOPLIST_FILE = "CoreParse/CoreParse-Info.plist";
 				INSTALL_PATH = "@rpath";
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				OTHER_CFLAGS = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_AFTER_BUILD = YES;
@@ -1214,6 +1298,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				FRAMEWORK_SEARCH_PATHS = "$(DEVELOPER_LIBRARY_DIR)/Frameworks";
 				GCC_DYNAMIC_NO_PIC = NO;
@@ -1222,11 +1308,13 @@
 				GCC_PREFIX_HEADER = "CoreParseTests/CoreParseTests-Prefix.pch";
 				INFOPLIST_FILE = "CoreParseTests/CoreParseTests-Info.plist";
 				INSTALL_PATH = "$(USER_LIBRARY_DIR)/Bundles";
+				MACOSX_DEPLOYMENT_TARGET = 10.6.8;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SenTestingKit,
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
 				WRAPPER_EXTENSION = octest;
 			};
 			name = Debug;
@@ -1235,6 +1323,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				FRAMEWORK_SEARCH_PATHS = "$(DEVELOPER_LIBRARY_DIR)/Frameworks";
@@ -1243,11 +1333,13 @@
 				GCC_PREFIX_HEADER = "CoreParseTests/CoreParseTests-Prefix.pch";
 				INFOPLIST_FILE = "CoreParseTests/CoreParseTests-Info.plist";
 				INSTALL_PATH = "$(USER_LIBRARY_DIR)/Bundles";
+				MACOSX_DEPLOYMENT_TARGET = 10.6.8;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SenTestingKit,
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
 				WRAPPER_EXTENSION = octest;
 			};
 			name = Release;
@@ -1256,7 +1348,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				CLANG_ENABLE_OBJC_ARC = YES;
 				COPY_PHASE_STRIP = NO;
 				DSTROOT = /tmp/iOSCoreParse.dst;
 				GCC_DYNAMIC_NO_PIC = NO;
@@ -1267,10 +1359,13 @@
 					"$(inherited)",
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				IPHONEOS_DEPLOYMENT_TARGET = 4.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.6;
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = "-ObjC";
+				PRIVATE_HEADERS_FOLDER_PATH = CoreParse;
 				PRODUCT_NAME = CoreParse;
+				PUBLIC_HEADERS_FOLDER_PATH = CoreParse;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -1282,15 +1377,18 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				CLANG_ENABLE_OBJC_ARC = YES;
 				COPY_PHASE_STRIP = YES;
 				DSTROOT = /tmp/iOSCoreParse.dst;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "CoreParse/CoreParse-Prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 4.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.6;
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = "-ObjC";
+				PRIVATE_HEADERS_FOLDER_PATH = CoreParse;
 				PRODUCT_NAME = CoreParse;
+				PUBLIC_HEADERS_FOLDER_PATH = CoreParse;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -1303,7 +1401,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				COPY_PHASE_STRIP = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
@@ -1334,7 +1431,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				COPY_PHASE_STRIP = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
@@ -1360,7 +1456,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				COPY_PHASE_STRIP = NO;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
@@ -1375,7 +1470,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;

--- a/CoreParse/Built In Parsers/CPJSONParser.m
+++ b/CoreParse/Built In Parsers/CPJSONParser.m
@@ -99,19 +99,11 @@
                                   @"15 boolean  ::= 'true';"
                                   @"16 boolean  ::= 'false';"
                                                        error:NULL];
-        jsonParser = [[CPSLRParser parserWithGrammar:jsonGrammar] retain];
+        jsonParser = [CPSLRParser parserWithGrammar:jsonGrammar];
         [jsonParser setDelegate:self];
     }
     
     return self;
-}
-
-- (void)dealloc
-{
-    [jsonTokeniser release];
-    [jsonParser release];
-    
-    [super dealloc];
 }
 
 - (id<NSObject>)parse:(NSString *)json

--- a/CoreParse/Grammar/CPGrammar.h
+++ b/CoreParse/Grammar/CPGrammar.h
@@ -220,6 +220,6 @@ typedef enum
 /**
  * The starting symbol for the grammar.
  */
-@property (readwrite,retain) NSString *start;
+@property (readwrite,strong) NSString *start;
 
 @end

--- a/CoreParse/Grammar/CPGrammar.m
+++ b/CoreParse/Grammar/CPGrammar.m
@@ -35,7 +35,7 @@
 
 @interface CPBNFParserDelegate : NSObject <CPTokeniserDelegate,CPParserDelegate>
 
-@property (readwrite, retain, nonatomic) NSError *err;
+@property (readwrite, strong, nonatomic) NSError *err;
 
 @end
 
@@ -114,7 +114,7 @@
             }
             else
             {
-                CPRHSItem *newI = [[[CPRHSItem alloc] init] autorelease];
+                CPRHSItem *newI = [[CPRHSItem alloc] init];
                 [newI setAlternatives:[NSArray arrayWithObject:[NSArray arrayWithObject:i]]];
                 [newI setRepeats:NO];
                 [newI setMayNotExist:NO];
@@ -127,7 +127,7 @@
             return [children objectAtIndex:0];
         case 13:
         {
-            CPRHSItem *i = [[[CPRHSItem alloc] init] autorelease];
+            CPRHSItem *i = [[CPRHSItem alloc] init];
             [i setAlternatives:[NSArray arrayWithObject:[NSArray arrayWithObject:[children objectAtIndex:0]]]];
             NSString *symbol = [(CPKeywordToken *)[children objectAtIndex:1] keyword];
             if ([symbol isEqualToString:@"*"])
@@ -151,7 +151,7 @@
             return [children objectAtIndex:0];
         case 15:
         {
-            CPRHSItem *i = [[[CPRHSItem alloc] init] autorelease];
+            CPRHSItem *i = [[CPRHSItem alloc] init];
             [i setAlternatives:[children objectAtIndex:1]];
             [i setRepeats:NO];
             [i setMayNotExist:NO];
@@ -206,7 +206,7 @@
 
 + (id)grammarWithStart:(NSString *)start rules:(NSArray *)rules
 {
-    return [[[self alloc] initWithStart:start rules:rules] autorelease];
+    return [[self alloc] initWithStart:start rules:rules];
 }
 
 - (id)initWithStart:(NSString *)initStart rules:(NSArray *)initRules;
@@ -225,12 +225,12 @@
 
 + (id)grammarWithStart:(NSString *)start backusNaurForm:(NSString *)bnf
 {
-    return [[[self alloc] initWithStart:start backusNaurForm:bnf] autorelease];
+    return [[self alloc] initWithStart:start backusNaurForm:bnf];
 }
 
 + (id)grammarWithStart:(NSString *)start backusNaurForm:(NSString *)bnf error:(NSError **)error
 {
-    return [[[self alloc] initWithStart:start backusNaurForm:bnf error:error] autorelease];
+    return [[self alloc] initWithStart:start backusNaurForm:bnf error:error];
 }
 
 - (id)initWithStart:(NSString *)initStart backusNaurForm:(NSString *)bnf
@@ -247,8 +247,8 @@
 
 - (id)initWithStart:(NSString *)initStart backusNaurForm:(NSString *)bnf error:(NSError **)error
 {
-    CPBNFParserDelegate *del = [[[CPBNFParserDelegate alloc] init] autorelease];
-    CPTokeniser *tokeniser = [[[CPTokeniser alloc] init] autorelease];
+    CPBNFParserDelegate *del = [[CPBNFParserDelegate alloc] init];
+    CPTokeniser *tokeniser = [[CPTokeniser alloc] init];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@"::="]];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@"@"]];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@"<"]];
@@ -313,9 +313,8 @@
     {
         if (NULL != error)
         {
-            *error = [[[del err] copy] autorelease];
+            *error = [[del err] copy];
         }
-        [self release];
         return nil;
     }
     
@@ -326,14 +325,12 @@
         {
             *error = e;
         }
-        [self release];
         return nil;
     }
     
     NSArray *newRules = [self tidyRightHandSides:initRules error:error];
     if (nil == newRules)
     {
-        [self release];
         return nil;
     }
     
@@ -369,10 +366,7 @@
 
 - (void)dealloc
 {
-    [start release];
     [self setRules:nil];
-    
-    [super dealloc];
 }
 
 - (NSSet *)allRules
@@ -405,7 +399,7 @@
                 NSSet *usedNonTerminals = [(CPRHSItem *)item nonTerminalsUsed];
                 if (![usedNonTerminals isSubsetOfSet:definedNonTerminals])
                 {
-                    NSMutableSet *mutableUsedNonTerminals = [[usedNonTerminals mutableCopy] autorelease];
+                    NSMutableSet *mutableUsedNonTerminals = [usedNonTerminals mutableCopy];
                     [mutableUsedNonTerminals minusSet:definedNonTerminals];
                     return [NSError errorWithDomain:CPEBNFParserErrorDomain
                                                code:CPErrorCodeUndefinedNonTerminal

--- a/CoreParse/Grammar/CPGrammarInternal.m
+++ b/CoreParse/Grammar/CPGrammarInternal.m
@@ -24,9 +24,8 @@
 
 - (CPGrammar *)augmentedGrammar
 {
-    return [[[CPGrammar alloc] initWithStart:@"s'"
-                                       rules:[[self rules] arrayByAddingObject:[CPRule ruleWithName:@"s'" rightHandSideElements:[NSArray arrayWithObject:[CPGrammarSymbol nonTerminalWithName:[self start]]]]]]
-            autorelease];
+    return [[CPGrammar alloc] initWithStart:@"s'"
+                                       rules:[[self rules] arrayByAddingObject:[CPRule ruleWithName:@"s'" rightHandSideElements:[NSArray arrayWithObject:[CPGrammarSymbol nonTerminalWithName:[self start]]]]]];
 }
 
 - (NSUInteger)indexOfRule:(CPRule *)rule
@@ -73,9 +72,7 @@
         [processingQueue removeObjectAtIndex:0];
     }
     
-    [processingQueue release];
-    
-    return [j autorelease];
+    return j;
 }
 
 - (NSSet *)lr0GotoKernelWithItems:(NSSet *)i symbol:(CPGrammarSymbol *)symbol
@@ -152,9 +149,7 @@
         [processingQueue removeObjectAtIndex:0];
     }
     
-    [processingQueue release];
-    
-    return [j autorelease];
+    return j;
 }
 
 - (NSSet *)lr1GotoKernelWithItems:(NSSet *)i symbol:(CPGrammarSymbol *)symbol
@@ -232,7 +227,7 @@
 
 - (NSString *)symbolNameNotInSet:(NSSet *)symbols basedOnName:(NSString *)name
 {
-    NSString *testName = [[name copy] autorelease];
+    NSString *testName = [name copy];
     while ([symbols containsObject:testName])
     {
         testName = [NSString stringWithFormat:@"_%@", testName];
@@ -280,7 +275,7 @@
                 {
                     return error;
                 }
-                NSMutableSet *duplicateTags = [[tagNames mutableCopy] autorelease];
+                NSMutableSet *duplicateTags = [tagNames mutableCopy];
                 [duplicateTags intersectSet:newTagNames];
                 if ([duplicateTags count] > 0)
                 {
@@ -296,7 +291,7 @@
                 {
                     if ([tagNames intersectsSet:tns])
                     {
-                        NSMutableSet *intersection = [[tagNames mutableCopy] autorelease];
+                        NSMutableSet *intersection = [tagNames mutableCopy];
                         [intersection intersectSet:tns];
                         return [NSError errorWithDomain:CPEBNFParserErrorDomain
                                                    code:CPErrorCodeDuplicateTag
@@ -345,7 +340,7 @@
          
 - (NSArray *)addRHSRules:(NSDictionary *)newRules toRules:(NSArray *)oldRules
 {
-    NSMutableArray *rules = [[[NSMutableArray alloc] initWithArray:oldRules] autorelease];
+    NSMutableArray *rules = [[NSMutableArray alloc] initWithArray:oldRules];
     
     Class rhsItemClass = [CPRHSItemResult class];
     for (CPRHSItem *item in newRules)
@@ -362,12 +357,12 @@
             
             if ([item mayNotExist])
             {
-                rule = [[[CPRule alloc] initWithName:ruleName rightHandSideElements:[NSArray array]] autorelease];
+                rule = [[CPRule alloc] initWithName:ruleName rightHandSideElements:[NSArray array]];
                 [rule setTag:0];
             }
             else
             {
-                rule = [[[CPRule alloc] initWithName:ruleName rightHandSideElements:[[item alternatives] objectAtIndex:0]] autorelease];
+                rule = [[CPRule alloc] initWithName:ruleName rightHandSideElements:[[item alternatives] objectAtIndex:0]];
                 [rule setTag:1];
             }
             [rule setShouldCollapse:[item shouldCollapse]];
@@ -377,12 +372,12 @@
             
             if ([item repeats])
             {
-                rule = [[[CPRule alloc] initWithName:ruleName rightHandSideElements:[[[item alternatives] objectAtIndex:0] arrayByAddingObject:[CPGrammarSymbol nonTerminalWithName:ruleName]]] autorelease];
+                rule = [[CPRule alloc] initWithName:ruleName rightHandSideElements:[[[item alternatives] objectAtIndex:0] arrayByAddingObject:[CPGrammarSymbol nonTerminalWithName:ruleName]]];
                 [rule setTag:2];
             }
             else if ([item mayNotExist])
             {
-                rule = [[[CPRule alloc] initWithName:ruleName rightHandSideElements:[[item alternatives] objectAtIndex:0]] autorelease];
+                rule = [[CPRule alloc] initWithName:ruleName rightHandSideElements:[[item alternatives] objectAtIndex:0]];
                 [rule setTag:1];
             }
             else
@@ -403,7 +398,7 @@
             NSUInteger i = 0;
             for (NSArray *contents in [item alternatives])
             {
-                CPRule *rule = [[[CPRule alloc] initWithName:ruleName rightHandSideElements:contents] autorelease];
+                CPRule *rule = [[CPRule alloc] initWithName:ruleName rightHandSideElements:contents];
                 [rule setTag:3 + i];
                 [rule setRepresentitiveClass:rhsItemClass];
                 [rule setShouldCollapse:[item shouldCollapse]];

--- a/CoreParse/Grammar/CPGrammarPrivate.h
+++ b/CoreParse/Grammar/CPGrammarPrivate.h
@@ -14,8 +14,8 @@
 
 @property (readwrite,copy  ) NSArray *rules;
 
-@property (readwrite,retain) NSMutableDictionary *rulesByNonTerminal;
-@property (readwrite,retain) NSMutableDictionary *followCache;
+@property (readwrite,strong) NSMutableDictionary *rulesByNonTerminal;
+@property (readwrite,strong) NSMutableDictionary *followCache;
 
 - (NSArray *)orderedRules;
 

--- a/CoreParse/Grammar/CPGrammarSymbol.m
+++ b/CoreParse/Grammar/CPGrammarSymbol.m
@@ -15,12 +15,12 @@
 
 + (id)nonTerminalWithName:(NSString *)name
 {
-    return [[[self alloc] initWithName:name isTerminal:NO] autorelease];
+    return [[self alloc] initWithName:name isTerminal:NO];
 }
 
 + (id)terminalWithName:(NSString *)name
 {
-    return [[[self alloc] initWithName:name isTerminal:YES] autorelease];
+    return [[self alloc] initWithName:name isTerminal:YES];
 }
 
 - (id)initWithName:(NSString *)initName isTerminal:(BOOL)isTerminal;
@@ -95,13 +95,6 @@
     {
         return [NSString stringWithFormat:@"<%@>", [self name]];
     }
-}
-
-- (void)dealloc
-{
-    [name release];
-    
-    [super dealloc];
 }
 
 @end

--- a/CoreParse/Grammar/CPRHSItem.m
+++ b/CoreParse/Grammar/CPRHSItem.m
@@ -52,14 +52,6 @@
     return other;
 }
 
-- (void)dealloc
-{
-    [_alternatives release];
-    [_tags release];
-    
-    [super dealloc];
-}
-
 - (NSString *)description
 {
     NSMutableString *desc = [NSMutableString string];
@@ -101,14 +93,13 @@
 
 - (NSSet *)tags
 {
-    return [[_tags retain] autorelease];
+    return _tags;
 }
 
 - (void)setTags:(NSSet *)tags
 {
     if (tags != _tags)
     {
-        [_tags release];
         _tags = [tags mutableCopy];
     }
 }
@@ -162,7 +153,7 @@
                 {
                     return nil;
                 }
-                NSMutableSet *duplicateTags = [[tagNamesInAlternative mutableCopy] autorelease];
+                NSMutableSet *duplicateTags = [tagNamesInAlternative mutableCopy];
                 [duplicateTags intersectSet:newTagNames];
                 if ([duplicateTags count] > 0)
                 {
@@ -184,7 +175,7 @@
                     {
                         if (NULL != err)
                         {
-                            NSMutableSet *intersection = [[tagNamesInAlternative mutableCopy] autorelease];
+                            NSMutableSet *intersection = [tagNamesInAlternative mutableCopy];
                             [intersection intersectSet:tns];
                             *err = [NSError errorWithDomain:CPEBNFParserErrorDomain
                                                        code:CPErrorCodeDuplicateTag

--- a/CoreParse/Grammar/CPRHSItemResult.h
+++ b/CoreParse/Grammar/CPRHSItemResult.h
@@ -12,7 +12,7 @@
 
 @interface CPRHSItemResult : NSObject <CPParseResult>
 
-@property (readwrite, retain) NSMutableArray *contents;
+@property (readwrite, strong) NSMutableArray *contents;
 @property (readwrite, assign) BOOL shouldCollapse;
 @property (readwrite, copy  ) NSSet *tagNames;
 @property (readwrite, copy  ) NSDictionary *tagValues;

--- a/CoreParse/Grammar/CPRHSItemResult.m
+++ b/CoreParse/Grammar/CPRHSItemResult.m
@@ -32,7 +32,7 @@
                 [self setContents:[NSMutableArray array]];
                 break;
             case 1:
-                [self setContents:[[children mutableCopy] autorelease]];
+                [self setContents:[children mutableCopy]];
                 break;
             case 2:
             {
@@ -47,7 +47,7 @@
                 break;
             }
             default:
-                [self setContents:[[children mutableCopy] autorelease]];
+                [self setContents:[children mutableCopy]];
                 break;
         }
         
@@ -57,15 +57,6 @@
     }
     
     return self;
-}
-
-- (void)dealloc
-{
-    [_contents release];
-    [_tagNames release];
-    [_tagValues release];
-    
-    [super dealloc];
 }
 
 - (BOOL)isRHSItemResult

--- a/CoreParse/Grammar/CPRule.h
+++ b/CoreParse/Grammar/CPRule.h
@@ -116,7 +116,7 @@
 /**
  * Specifies the name of the non-terminal this rule describes.
  */
-@property (readwrite, retain) NSString *name;
+@property (readwrite, strong) NSString *name;
 
 /**
  * Specifies the right hand side of the rule.

--- a/CoreParse/Grammar/CPRule.m
+++ b/CoreParse/Grammar/CPRule.m
@@ -24,7 +24,7 @@
 
 - (NSArray *)rightHandSideElements
 {
-    return [[rightHandSide retain] autorelease];
+    return rightHandSide;
 }
 
 - (void)setRightHandSideElements:(NSArray *)rightHandSideElements
@@ -33,7 +33,6 @@
     {
         if (rightHandSide != rightHandSideElements)
         {
-            [rightHandSide release];
             rightHandSide = [rightHandSideElements mutableCopy];
         }
     }
@@ -41,7 +40,7 @@
 
 + (id)ruleWithName:(NSString *)name rightHandSideElements:(NSArray *)rightHandSideElements representitiveClass:(Class)representitiveClass
 {
-    return [[[self alloc] initWithName:name rightHandSideElements:rightHandSideElements representitiveClass:representitiveClass] autorelease];
+    return [[self alloc] initWithName:name rightHandSideElements:rightHandSideElements representitiveClass:representitiveClass];
 }
 
 - (id)initWithName:(NSString *)initName rightHandSideElements:(NSArray *)rightHandSideElements representitiveClass:(Class)initRepresentitiveClass
@@ -61,7 +60,7 @@
 
 + (id)ruleWithName:(NSString *)name rightHandSideElements:(NSArray *)rightHandSideElements tag:(NSUInteger)tag
 {
-    return [[[self alloc] initWithName:name rightHandSideElements:rightHandSideElements tag:tag] autorelease];
+    return [[self alloc] initWithName:name rightHandSideElements:rightHandSideElements tag:tag];
 }
 
 - (id)initWithName:(NSString *)initName rightHandSideElements:(NSArray *)rightHandSideElements tag:(NSUInteger)initTag
@@ -78,7 +77,7 @@
 
 + (id)ruleWithName:(NSString *)name rightHandSideElements:(NSArray *)rightHandSideElements
 {
-    return [[[CPRule alloc] initWithName:name rightHandSideElements:rightHandSideElements] autorelease];
+    return [[CPRule alloc] initWithName:name rightHandSideElements:rightHandSideElements];
 }
 
 - (id)initWithName:(NSString *)initName rightHandSideElements:(NSArray *)rightHandSideElements
@@ -117,14 +116,6 @@
     [aCoder encodeObject:[self name] forKey:CPRuleNameKey];
     [aCoder encodeObject:[self rightHandSideElements] forKey:CPRuleRHSElementsKey];
     [aCoder encodeObject:NSStringFromClass([self representitiveClass]) forKey:CPRuleRepresentitiveClassKey];
-}
-
-- (void)dealloc
-{
-    [name release];
-    [rightHandSide release];
-    
-    [super dealloc];
 }
 
 - (NSString *)description
@@ -167,14 +158,13 @@
 
 - (NSSet *)tagNames
 {
-    return [[_tagNames retain] autorelease];
+    return _tagNames;
 }
 
 - (void)setTagNames:(NSSet *)tagNames
 {
     if (_tagNames != tagNames)
     {
-        [_tagNames release];
         _tagNames = [tagNames copy];
     }
 }

--- a/CoreParse/NSArray+Functional.m
+++ b/CoreParse/NSArray+Functional.m
@@ -12,23 +12,18 @@
 
 - (NSArray *)map:(id(^)(id obj))block
 {
-    NSUInteger c = [self count];
-    id *resultingObjects = malloc(c * sizeof(id));
+    NSMutableArray *resultingObjects = [NSMutableArray arrayWithCapacity:[self count]];
     
-    NSUInteger nonNilCount = 0;
     for (id obj in self)
     {
         id r = block(obj);
         if (nil != r)
         {
-            resultingObjects[nonNilCount] = r;
-            nonNilCount++;
+            [resultingObjects addObject:r];
         }
     }
     
-    NSArray *a = [NSArray arrayWithObjects:resultingObjects count:nonNilCount];
-    free(resultingObjects);
-    return a;
+    return resultingObjects;
 }
 
 @end

--- a/CoreParse/NSSetFunctional.m
+++ b/CoreParse/NSSetFunctional.m
@@ -13,23 +13,18 @@
 
 - (NSSet *)map:(id(^)(id obj))block
 {
-    NSUInteger c = [self count];
-    id *resultingObjects = malloc(c * sizeof(id));
+    NSMutableSet *resultingObjects = [NSMutableSet setWithCapacity:[self count]];
     
-    NSUInteger nonNilCount = 0;
     for (id obj in self)
     {
         id r = block(obj);
         if (nil != r)
         {
-            resultingObjects[nonNilCount] = r;
-            nonNilCount++;
+            [resultingObjects addObject:r];
         }
     }
     
-    NSSet *s = [NSSet setWithObjects:resultingObjects count:nonNilCount];
-    free(resultingObjects);
-    return s;
+    return resultingObjects;
 }
 
 @end

--- a/CoreParse/Parsers/CPParser.h
+++ b/CoreParse/Parsers/CPParser.h
@@ -127,7 +127,7 @@ typedef struct
 /**
  * The parser's delegate.
  */
-@property (readwrite,assign, nonatomic) id<CPParserDelegate> delegate;
+@property (readwrite, strong, nonatomic) id<CPParserDelegate> delegate;
 
 ///---------------------------------------------------------------------------------------
 /// @name Finding out about the parsed Grammar 
@@ -136,7 +136,7 @@ typedef struct
 /**
  * The parser's grammar.
  */
-@property (readonly,retain) CPGrammar *grammar;
+@property (readonly,strong) CPGrammar *grammar;
 
 ///---------------------------------------------------------------------------------------
 /// @name Parsing a Token Stream.

--- a/CoreParse/Parsers/CPParser.m
+++ b/CoreParse/Parsers/CPParser.m
@@ -10,7 +10,7 @@
 
 @interface CPParser ()
 
-@property (readwrite,retain) CPGrammar *grammar;
+@property (readwrite,strong) CPGrammar *grammar;
 
 @end
 
@@ -21,7 +21,7 @@
 
 + (id)parserWithGrammar:(CPGrammar *)grammar
 {
-    return [[[self alloc] initWithGrammar:grammar] autorelease];
+    return [[self alloc] initWithGrammar:grammar];
 }
 
 - (id)initWithGrammar:(CPGrammar *)initGrammar
@@ -39,13 +39,6 @@
 - (id)init
 {
     return [self initWithGrammar:nil];
-}
-
-- (void)dealloc
-{
-    [grammar release];
-    
-    [super dealloc];
 }
 
 - (id)parse:(CPTokenStream *)tokenStream

--- a/CoreParse/Parsers/CPShiftReduceParsers/CPItem.h
+++ b/CoreParse/Parsers/CPShiftReduceParsers/CPItem.h
@@ -14,7 +14,7 @@
 @interface CPItem : NSObject <NSCopying>
 {}
 
-@property (readonly,retain) CPRule *rule;
+@property (readonly,strong) CPRule *rule;
 @property (readonly,assign) NSUInteger position;
 
 + (id)itemWithRule:(CPRule *)rule position:(NSUInteger)position;

--- a/CoreParse/Parsers/CPShiftReduceParsers/CPItem.m
+++ b/CoreParse/Parsers/CPShiftReduceParsers/CPItem.m
@@ -10,7 +10,7 @@
 
 @interface CPItem ()
 
-@property (readwrite,retain) CPRule *rule;
+@property (readwrite,strong) CPRule *rule;
 @property (readwrite,assign) NSUInteger position;
 
 @end
@@ -22,7 +22,7 @@
 
 + (id)itemWithRule:(CPRule *)rule position:(NSUInteger)position
 {
-    return [[[self alloc] initWithRule:rule position:position] autorelease];
+    return [[self alloc] initWithRule:rule position:position];
 }
 
 - (id)initWithRule:(CPRule *)initRule position:(NSUInteger)initPosition
@@ -31,7 +31,7 @@
     
     if (nil != self)
     {
-        rule = [initRule retain];
+        rule = initRule;
         position = initPosition;
     }
     
@@ -41,13 +41,6 @@
 - (id)copyWithZone:(NSZone *)zone
 {
     return [[CPItem allocWithZone:zone] initWithRule:rule position:position];
-}
-
-- (void)dealloc
-{
-    [rule release];
-    
-    [super dealloc];
 }
 
 - (CPGrammarSymbol *)nextSymbol
@@ -73,7 +66,7 @@
 {
     CPItem *c = [self copy];
     [c setPosition:[self position] + 1];
-    return [c autorelease];
+    return c;
 }
 
 - (BOOL)isItem

--- a/CoreParse/Parsers/CPShiftReduceParsers/CPLR1Item.h
+++ b/CoreParse/Parsers/CPShiftReduceParsers/CPLR1Item.h
@@ -14,7 +14,7 @@
 @interface CPLR1Item : CPItem
 {}
 
-@property (readonly,retain) CPGrammarSymbol *terminal;
+@property (readonly,strong) CPGrammarSymbol *terminal;
 
 + (id)lr1ItemWithRule:(CPRule *)rule position:(NSUInteger)position terminal:(CPGrammarSymbol *)terminal;
 - (id)initWithRule:(CPRule *)rule position:(NSUInteger)position terminal:(CPGrammarSymbol *)terminal;

--- a/CoreParse/Parsers/CPShiftReduceParsers/CPLR1Item.m
+++ b/CoreParse/Parsers/CPShiftReduceParsers/CPLR1Item.m
@@ -10,7 +10,7 @@
 
 @interface CPLR1Item ()
 
-@property (readwrite,retain) CPGrammarSymbol *terminal;
+@property (readwrite,strong) CPGrammarSymbol *terminal;
 
 @end
 
@@ -20,7 +20,7 @@
 
 + (id)lr1ItemWithRule:(CPRule *)rule position:(NSUInteger)position terminal:(CPGrammarSymbol *)terminal
 {
-    return [[[self alloc] initWithRule:rule position:position terminal:terminal] autorelease];
+    return [[self alloc] initWithRule:rule position:position terminal:terminal];
 }
 
 - (id)initWithRule:(CPRule *)rule position:(NSUInteger)position terminal:(CPGrammarSymbol *)initTerminal
@@ -43,13 +43,6 @@
 - (id)copyWithZone:(NSZone *)zone
 {
     return [[CPLR1Item allocWithZone:zone] initWithRule:[self rule] position:[self position] terminal:[self terminal]];
-}
-
-- (void)dealloc
-{
-    [terminal release];
-    
-    [super dealloc];
 }
 
 - (BOOL)isLR1Item

--- a/CoreParse/Parsers/CPShiftReduceParsers/CPLR1Parser.m
+++ b/CoreParse/Parsers/CPShiftReduceParsers/CPLR1Parser.m
@@ -35,8 +35,8 @@
     NSArray *allNonTerminalNames = [[self grammar] allNonTerminalNames];
     NSString *startSymbol = [aug start];
     
-    [self setActionTable:[[[CPShiftReduceActionTable alloc] initWithCapacity:itemCount] autorelease]];
-    [self setGotoTable:  [[[CPShiftReduceGotoTable   alloc] initWithCapacity:itemCount] autorelease]];
+    [self setActionTable:[[CPShiftReduceActionTable alloc] initWithCapacity:itemCount]];
+    [self setGotoTable:  [[CPShiftReduceGotoTable   alloc] initWithCapacity:itemCount]];
     
     NSUInteger idx = 0;
     for (NSSet *kernel in kernels)

--- a/CoreParse/Parsers/CPShiftReduceParsers/CPSLRParser.m
+++ b/CoreParse/Parsers/CPShiftReduceParsers/CPSLRParser.m
@@ -32,8 +32,8 @@
     NSUInteger itemCount = [kernels count];
     NSString *startSymbol = [aug start];
     
-    [self setActionTable:[[[CPShiftReduceActionTable alloc] initWithCapacity:itemCount] autorelease]];
-    [self setGotoTable:  [[[CPShiftReduceGotoTable   alloc] initWithCapacity:itemCount] autorelease]];
+    [self setActionTable:[[CPShiftReduceActionTable alloc] initWithCapacity:itemCount]];
+    [self setGotoTable:  [[CPShiftReduceGotoTable   alloc] initWithCapacity:itemCount]];
     
     NSArray *allNonTerminalNames = [[self grammar] allNonTerminalNames];
     NSUInteger idx = 0;

--- a/CoreParse/Parsers/CPShiftReduceParsers/CPShiftReduceAction.m
+++ b/CoreParse/Parsers/CPShiftReduceParsers/CPShiftReduceAction.m
@@ -17,32 +17,26 @@ typedef enum
     kActionTypeAccept
 } ActionType;
 
-typedef union
-{
-    NSUInteger shift;
-    CPRule *reductionRule;
-}
-ActionDetails;
-
 @implementation CPShiftReduceAction
 {
     ActionType type;
-    ActionDetails details;
+    NSUInteger shift;
+    CPRule *reductionRule;
 }
 
 + (id)shiftAction:(NSUInteger)shiftLocation
 {
-    return [[[self alloc] initWithShift:shiftLocation] autorelease];
+    return [[self alloc] initWithShift:shiftLocation];
 }
 
 + (id)reduceAction:(CPRule *)reduction
 {
-    return [[[self alloc] initWithReductionRule:reduction] autorelease];
+    return [[self alloc] initWithReductionRule:reduction];
 }
 
 + (id)acceptAction
 {
-    return [[[self alloc] init] autorelease];
+    return [[self alloc] init];
 }
 
 - (id)initWithShift:(NSUInteger)shiftLocation
@@ -52,7 +46,7 @@ ActionDetails;
     if (nil != self)
     {
         type = kActionTypeShift;
-        details.shift = shiftLocation;
+        shift = shiftLocation;
     }
     
     return self;
@@ -65,7 +59,7 @@ ActionDetails;
     if (nil != self)
     {
         type = kActionTypeReduce;
-        details.reductionRule = [reduction retain];
+        reductionRule = reduction;
     }
     
     return self;
@@ -97,10 +91,10 @@ ActionDetails;
         switch (type)
         {
             case kActionTypeShift:
-                details.shift = [aDecoder decodeIntegerForKey:CPShiftReduceActionShiftKey];
+                shift = [aDecoder decodeIntegerForKey:CPShiftReduceActionShiftKey];
                 break;
             case kActionTypeReduce:
-                details.reductionRule = [[aDecoder decodeObjectForKey:CPShiftReduceActionRuleKey] retain];
+                reductionRule = [aDecoder decodeObjectForKey:CPShiftReduceActionRuleKey];
             case kActionTypeAccept:
             default:
                 break;
@@ -116,24 +110,14 @@ ActionDetails;
     switch (type)
     {
         case kActionTypeShift:
-            [aCoder encodeInteger:details.shift forKey:CPShiftReduceActionShiftKey];
+            [aCoder encodeInteger:shift forKey:CPShiftReduceActionShiftKey];
             break;
         case kActionTypeReduce:
-            [aCoder encodeObject:details.reductionRule forKey:CPShiftReduceActionRuleKey];
+            [aCoder encodeObject:reductionRule forKey:CPShiftReduceActionRuleKey];
         case kActionTypeAccept:
         default:
             break;
     }
-}
-
-- (void)dealloc
-{
-    if (kActionTypeReduce == type)
-    {
-        [details.reductionRule release];
-    }
-    
-    [super dealloc];
 }
 
 - (BOOL)isShiftAction
@@ -153,12 +137,12 @@ ActionDetails;
 
 - (NSUInteger)newState
 {
-    return details.shift;
+    return shift;
 }
 
 - (CPRule *)reductionRule
 {
-    return details.reductionRule;
+    return reductionRule;
 }
 
 - (NSUInteger)hash
@@ -179,9 +163,9 @@ ActionDetails;
         switch (type)
         {
             case kActionTypeShift:
-                return [other newState] == details.shift;
+                return [other newState] == shift;
             case kActionTypeReduce:
-                return [other reductionRule] == details.reductionRule;
+                return [other reductionRule] == reductionRule;
             case kActionTypeAccept:
                 return YES;
         }
@@ -197,9 +181,9 @@ ActionDetails;
         switch (type)
         {
             case kActionTypeShift:
-                return [object newState] == details.shift;
+                return [object newState] == shift;
             case kActionTypeReduce:
-                return [object reductionRule] == details.reductionRule;
+                return [object reductionRule] == reductionRule;
             case kActionTypeAccept:
                 return YES;
         }
@@ -213,9 +197,9 @@ ActionDetails;
     switch (type)
     {
         case kActionTypeShift:
-            return [NSString stringWithFormat:@"s%ld", (long)details.shift];
+            return [NSString stringWithFormat:@"s%ld", (long)shift];
         case kActionTypeReduce:
-            return [NSString stringWithFormat:@"r%@", [details.reductionRule name]];
+            return [NSString stringWithFormat:@"r%@", [reductionRule name]];
         case kActionTypeAccept:
             return @"acc";
     }
@@ -226,9 +210,9 @@ ActionDetails;
     switch (type)
     {
         case kActionTypeShift:
-            return [NSString stringWithFormat:@"s%ld", (long)details.shift];
+            return [NSString stringWithFormat:@"s%ld", (long)shift];
         case kActionTypeReduce:
-            return [NSString stringWithFormat:@"r%ld", (long)[g indexOfRule:details.reductionRule]];
+            return [NSString stringWithFormat:@"r%ld", (long)[g indexOfRule:reductionRule]];
         case kActionTypeAccept:
             return @"acc";
     }

--- a/CoreParse/Parsers/CPShiftReduceParsers/CPShiftReduceGotoTable.m
+++ b/CoreParse/Parsers/CPShiftReduceParsers/CPShiftReduceGotoTable.m
@@ -7,11 +7,11 @@
 //
 
 #import "CPShiftReduceGotoTable.h"
-
+#import "CPRule.h"
 
 @implementation CPShiftReduceGotoTable
 {
-    NSMutableDictionary **table;
+    NSMutableArray *table;
     NSUInteger capacity;
 }
 
@@ -22,10 +22,11 @@
     if (nil != self)
     {
         capacity = initCapacity;
-        table = malloc(capacity * sizeof(NSMutableDictionary *));
-        for (NSUInteger buildingState = 0; buildingState < capacity; buildingState++)
+        table = [NSMutableArray arrayWithCapacity:capacity];
+        
+        for (NSUInteger i = 0; i < initCapacity; ++i)
         {
-            table[buildingState] = [[NSMutableDictionary alloc] init];
+            [table addObject:[[NSMutableDictionary alloc] init]];
         }
     }
     
@@ -40,14 +41,7 @@
     
     if (nil != self)
     {
-        NSArray *rows = [aDecoder decodeObjectForKey:CPShiftReduceGotoTableTableKey];
-        capacity = [rows count];
-        table = malloc(capacity * sizeof(NSMutableDictionary *));
-        [rows getObjects:table range:NSMakeRange(0, capacity)];
-        for (NSUInteger i = 0; i < capacity; i++)
-        {
-            [table[i] retain];
-        }
+        table = [aDecoder decodeObjectForKey:CPShiftReduceGotoTableTableKey];
     }
     
     return self;
@@ -55,18 +49,7 @@
 
 - (void)encodeWithCoder:(NSCoder *)aCoder
 {
-    [aCoder encodeObject:[NSArray arrayWithObjects:table count:capacity] forKey:CPShiftReduceGotoTableTableKey];
-}
-
-- (void)dealloc
-{
-    for (NSUInteger state = 0; state < capacity; state++)
-    {
-        [table[state] release];
-    }
-    free(table);
-    
-    [super dealloc];
+    [aCoder encodeObject:table forKey:CPShiftReduceGotoTableTableKey];
 }
 
 - (BOOL)setGoto:(NSUInteger)gotoIndex forState:(NSUInteger)state nonTerminalNamed:(NSString *)nonTerminalName
@@ -82,7 +65,8 @@
 
 - (NSUInteger)gotoForState:(NSUInteger)state rule:(CPRule *)rule
 {
-    return [(NSNumber *)[table[state] objectForKey:[rule name]] unsignedIntegerValue];
+    NSMutableDictionary *row = table[state];
+    return [(NSNumber *)[row objectForKey:[rule name]] unsignedIntegerValue];
 }
 
 @end

--- a/CoreParse/Parsers/CPShiftReduceParsers/CPShiftReduceParserProtectedMethods.h
+++ b/CoreParse/Parsers/CPShiftReduceParsers/CPShiftReduceParserProtectedMethods.h
@@ -15,8 +15,8 @@
 
 @interface CPShiftReduceParser ()
 
-@property (readwrite,retain) CPShiftReduceActionTable *actionTable;
-@property (readwrite,retain) CPShiftReduceGotoTable *gotoTable;
+@property (readwrite,strong) CPShiftReduceActionTable *actionTable;
+@property (readwrite,strong) CPShiftReduceGotoTable *gotoTable;
 
 - (BOOL)constructShiftReduceTables;
 

--- a/CoreParse/Parsers/CPShiftReduceParsers/CPShiftReduceState.h
+++ b/CoreParse/Parsers/CPShiftReduceParsers/CPShiftReduceState.h
@@ -10,7 +10,7 @@
 
 @interface CPShiftReduceState : NSObject
 
-@property (readonly,retain) NSObject *object;
+@property (readonly,strong) NSObject *object;
 @property (readonly,assign) NSUInteger state;
 
 + (id)shiftReduceStateWithObject:(NSObject *)object state:(NSUInteger)state;

--- a/CoreParse/Parsers/CPShiftReduceParsers/CPShiftReduceState.m
+++ b/CoreParse/Parsers/CPShiftReduceParsers/CPShiftReduceState.m
@@ -10,7 +10,7 @@
 
 @interface CPShiftReduceState ()
 
-@property (readwrite,retain) NSObject *object;
+@property (readwrite,strong) NSObject *object;
 @property (readwrite,assign) NSUInteger state;
 
 @end
@@ -22,7 +22,7 @@
 
 + (id)shiftReduceStateWithObject:(NSObject *)object state:(NSUInteger)state
 {
-    return [[[self alloc] initWithObject:object state:state] autorelease];
+    return [[self alloc] initWithObject:object state:state];
 }
 
 - (id)initWithObject:(NSObject *)initObject state:(NSUInteger)initState
@@ -36,13 +36,6 @@
     }
     
     return self;
-}
-
-- (void)dealloc
-{
-    [object release];
-    
-    [super dealloc];
 }
 
 - (NSString *)description

--- a/CoreParse/Parsers/Error Recovery/CPRecoveryAction.h
+++ b/CoreParse/Parsers/Error Recovery/CPRecoveryAction.h
@@ -30,7 +30,7 @@ typedef enum
 /**
  * The token to insert in the token streem if a CPRecoveryTypeAddToken action is taken.
  */
-@property (readwrite, retain) CPToken *additionalToken;
+@property (readwrite, strong) CPToken *additionalToken;
 
 /**
  * Allocates an initialises a new CPRecoveryAction asking the parser to add a new token to the token stream.

--- a/CoreParse/Parsers/Error Recovery/CPRecoveryAction.m
+++ b/CoreParse/Parsers/Error Recovery/CPRecoveryAction.m
@@ -15,17 +15,17 @@
 
 + (id)recoveryActionWithAdditionalToken:(CPToken *)token
 {
-    return [[[self alloc] initWithAdditionalToken:token] autorelease];
+    return [[self alloc] initWithAdditionalToken:token];
 }
 
 + (id)recoveryActionDeletingCurrentToken
 {
-    return [[[self alloc] initWithDeleteAction] autorelease];
+    return [[self alloc] initWithDeleteAction];
 }
 
 + (id)recoveryActionStop
 {
-    return [[[self alloc] initWithStopAction] autorelease];
+    return [[self alloc] initWithStopAction];
 }
 
 - (id)initWithAdditionalToken:(CPToken *)token
@@ -63,13 +63,6 @@
     }
     
     return self;
-}
-
-- (void)dealloc
-{
-    [additionalToken release];
-    
-    [super dealloc];
 }
 
 @end

--- a/CoreParse/Syntax Tree/CPSyntaxTree.h
+++ b/CoreParse/Syntax Tree/CPSyntaxTree.h
@@ -76,7 +76,7 @@
 /**
  * The rule matched to create this syntax tree.
  */
-@property (readonly,retain) CPRule *rule;
+@property (readonly,strong) CPRule *rule;
 
 /**
  * The children that match the right hand side of the matched rule.

--- a/CoreParse/Syntax Tree/CPSyntaxTree.m
+++ b/CoreParse/Syntax Tree/CPSyntaxTree.m
@@ -10,7 +10,7 @@
 
 @interface CPSyntaxTree ()
 
-@property (readwrite,retain) CPRule *rule;
+@property (readwrite,strong) CPRule *rule;
 @property (readwrite,copy) NSArray *children;
 @property (readwrite,copy) NSDictionary *tagValues;
 
@@ -24,7 +24,7 @@
 
 + (id)syntaxTreeWithRule:(CPRule *)rule children:(NSArray *)children
 {
-    return [[[self alloc] initWithRule:rule children:children tagValues:[NSDictionary dictionary]] autorelease];
+    return [[self alloc] initWithRule:rule children:children tagValues:[NSDictionary dictionary]];
 }
 
 - (id)initWithRule:(CPRule *)initRule children:(NSArray *)initChildren;
@@ -34,7 +34,7 @@
 
 + (id)syntaxTreeWithRule:(CPRule *)rule children:(NSArray *)children tagValues:(NSDictionary *)tagValues;
 {
-    return [[[self alloc] initWithRule:rule children:children tagValues:tagValues] autorelease];
+    return [[self alloc] initWithRule:rule children:children tagValues:tagValues];
 }
 
 - (id)initWithRule:(CPRule *)initRule children:(NSArray *)initChildren tagValues:(NSDictionary *)initTagValues
@@ -54,15 +54,6 @@
 - (id)init
 {
     return [self initWithRule:nil children:[NSArray array] tagValues:[NSDictionary dictionary]];
-}
-
-- (void)dealloc
-{
-    [rule release];
-    [children release];
-    [tagValues release];
-    
-    [super dealloc];
 }
 
 - (id)valueForTag:(NSString *)tagName

--- a/CoreParse/Tokenisation/CPTokenStream.m
+++ b/CoreParse/Tokenisation/CPTokenStream.m
@@ -31,7 +31,7 @@ typedef enum
 
 + (id)tokenStreamWithTokens:(NSArray *)tokens
 {
-    return [[[self alloc] initWithTokens:tokens] autorelease];
+    return [[self alloc] initWithTokens:tokens];
 }
 
 - (id)initWithTokens:(NSArray *)initTokens
@@ -40,7 +40,7 @@ typedef enum
     
     if (nil != self)
     {
-        [self setTokens:[[initTokens mutableCopy] autorelease]];
+        [self setTokens:[initTokens mutableCopy]];
     }
     
     return self;
@@ -60,14 +60,6 @@ typedef enum
     return self;
 }
 
-- (void)dealloc
-{
-    [tokens release];
-    [readWriteLock release];
-    
-    [super dealloc];
-}
-
 - (CPToken *)peekToken
 {
     [readWriteLock lockWhenCondition:CPTokenStreamAvailable];
@@ -75,7 +67,7 @@ typedef enum
     
     if ([tokens count] > 0)
     {
-        token = [[[tokens objectAtIndex:0] retain] autorelease];
+        token = [tokens objectAtIndex:0];
     }
     [readWriteLock unlockWithCondition:CPTokenStreamAvailable];
     
@@ -88,7 +80,7 @@ typedef enum
     CPToken *token = nil;
     if ([tokens count] > 0)
     {
-        token = [[[tokens objectAtIndex:0] retain] autorelease];
+        token = [tokens objectAtIndex:0];
         [tokens removeObjectAtIndex:0];
     }
     [self unlockTokenStream];
@@ -98,7 +90,7 @@ typedef enum
 
 - (NSArray *)tokens
 {
-    return [[tokens copy] autorelease];
+    return [tokens copy];
 }
 
 - (void)setTokens:(NSMutableArray *)newTokens
@@ -106,7 +98,6 @@ typedef enum
     [readWriteLock lock];
     if (tokens != newTokens)
     {
-        [tokens release];
         tokens = [newTokens mutableCopy];
     }
     [self unlockTokenStream];

--- a/CoreParse/Tokenisation/CPTokeniser.h
+++ b/CoreParse/Tokenisation/CPTokeniser.h
@@ -91,7 +91,7 @@
 /**
  * The object that acts as a delegate to the receiving CPTokeniser.
  */
-@property (readwrite, assign, nonatomic) id<CPTokeniserDelegate> delegate;
+@property (readwrite, strong, nonatomic) id<CPTokeniserDelegate> delegate;
 
 ///---------------------------------------------------------------------------------------
 /// @name Managing recognised tokens

--- a/CoreParse/Tokenisation/Token Recognisers/CPIdentifierRecogniser.h
+++ b/CoreParse/Tokenisation/Token Recognisers/CPIdentifierRecogniser.h
@@ -63,13 +63,13 @@
  * 
  * @see identifierCharacters
  */
-@property (readwrite,retain) NSCharacterSet *initialCharacters;
+@property (readwrite,strong) NSCharacterSet *initialCharacters;
 
 /**
  * Specifies the set of characters the recognised identifiers may contain, other than their first character.
  *
  * @see initialCharacters
  */
-@property (readwrite,retain) NSCharacterSet *identifierCharacters;
+@property (readwrite,strong) NSCharacterSet *identifierCharacters;
 
 @end

--- a/CoreParse/Tokenisation/Token Recognisers/CPIdentifierRecogniser.m
+++ b/CoreParse/Tokenisation/Token Recognisers/CPIdentifierRecogniser.m
@@ -17,12 +17,12 @@
 
 + (id)identifierRecogniser
 {
-    return [[[CPIdentifierRecogniser alloc] initWithInitialCharacters:nil identifierCharacters:nil] autorelease];
+    return [[CPIdentifierRecogniser alloc] initWithInitialCharacters:nil identifierCharacters:nil];
 }
 
 + (id)identifierRecogniserWithInitialCharacters:(NSCharacterSet *)initialCharacters identifierCharacters:(NSCharacterSet *)identifierCharacters
 {
-    return [[[CPIdentifierRecogniser alloc] initWithInitialCharacters:initialCharacters identifierCharacters:identifierCharacters] autorelease];
+    return [[CPIdentifierRecogniser alloc] initWithInitialCharacters:initialCharacters identifierCharacters:identifierCharacters];
 }
 
 - (id)initWithInitialCharacters:(NSCharacterSet *)initInitialCharacters identifierCharacters:(NSCharacterSet *)initIdentifierCharacters
@@ -60,14 +60,6 @@
     [aCoder encodeObject:[self identifierCharacters] forKey:CPIdentifierRecogniserIdentifierCharactersKey];
 }
 
-- (void)dealloc
-{
-    [initialCharacters release];
-    [identifierCharacters release];
-    
-    [super dealloc];
-}
-
 - (CPToken *)recogniseTokenInString:(NSString *)tokenString currentTokenPosition:(NSUInteger *)tokenPosition
 {
     NSCharacterSet *identifierStartCharacters = nil == [self initialCharacters] ? [NSCharacterSet characterSetWithCharactersInString:
@@ -89,12 +81,12 @@
         BOOL success = [scanner scanCharactersFromSet:idCharacters intoString:&identifierString];
         if (success)
         {
-            identifierString = [[[[NSString alloc] initWithCharacters:&firstChar length:1] autorelease] stringByAppendingString:identifierString];
+            identifierString = [[[NSString alloc] initWithCharacters:&firstChar length:1] stringByAppendingString:identifierString];
             *tokenPosition = [scanner scanLocation];
         }
         else
         {
-            identifierString = [[[NSString alloc] initWithCharacters:&firstChar length:1] autorelease];
+            identifierString = [[NSString alloc] initWithCharacters:&firstChar length:1];
             *tokenPosition += 1;
         }
         return [CPIdentifierToken tokenWithIdentifier:identifierString];

--- a/CoreParse/Tokenisation/Token Recognisers/CPKeywordRecogniser.h
+++ b/CoreParse/Tokenisation/Token Recognisers/CPKeywordRecogniser.h
@@ -82,11 +82,11 @@
 /**
  * The keyword that the recogniser should attempt to recognise.
  */
-@property (readwrite,retain,nonatomic) NSString *keyword;
+@property (readwrite,strong,nonatomic) NSString *keyword;
 
 /**
  * A set of characters that may not follow the keyword.
  */
-@property (readwrite,retain,nonatomic) NSCharacterSet *invalidFollowingCharacters;
+@property (readwrite,strong,nonatomic) NSCharacterSet *invalidFollowingCharacters;
 
 @end

--- a/CoreParse/Tokenisation/Token Recognisers/CPKeywordRecogniser.m
+++ b/CoreParse/Tokenisation/Token Recognisers/CPKeywordRecogniser.m
@@ -15,7 +15,7 @@
 
 + (id)recogniserForKeyword:(NSString *)keyword
 {
-    return [[[self alloc] initWithKeyword:keyword] autorelease];
+    return [[self alloc] initWithKeyword:keyword];
 }
 
 - (id)initWithKeyword:(NSString *)initKeyword
@@ -25,7 +25,7 @@
 
 + (id)recogniserForKeyword:(NSString *)keyword invalidFollowingCharacters:(NSCharacterSet *)invalidFollowingCharacters
 {
-    return [[[self alloc] initWithKeyword:keyword invalidFollowingCharacters:invalidFollowingCharacters] autorelease];
+    return [[self alloc] initWithKeyword:keyword invalidFollowingCharacters:invalidFollowingCharacters];
 }
 
 - (id)initWithKeyword:(NSString *)initKeyword invalidFollowingCharacters:(NSCharacterSet *)initInvalidFollowingCharacters
@@ -66,14 +66,6 @@
 {
     [aCoder encodeObject:[self keyword] forKey:CPKeywordRecogniserKeywordKey];
     [aCoder encodeObject:[self invalidFollowingCharacters] forKey:CPKeywordRecogniserInvalidFollowingCharactersKey];
-}
-
-- (void)dealloc
-{
-   [keyword release];
-   [invalidFollowingCharacters release];
-    
-    [super dealloc];
 }
 
 - (CPToken *)recogniseTokenInString:(NSString *)tokenString currentTokenPosition:(NSUInteger *)tokenPosition

--- a/CoreParse/Tokenisation/Token Recognisers/CPNumberRecogniser.m
+++ b/CoreParse/Tokenisation/Token Recognisers/CPNumberRecogniser.m
@@ -39,7 +39,7 @@
 
 + (id)integerRecogniser
 {
-    CPNumberRecogniser *rec = [[[CPNumberRecogniser alloc] init] autorelease];
+    CPNumberRecogniser *rec = [[CPNumberRecogniser alloc] init];
     [rec setRecognisesInts:YES];
     [rec setRecognisesFloats:NO];
     return rec;
@@ -47,7 +47,7 @@
 
 + (id)floatRecogniser
 {
-    CPNumberRecogniser *rec = [[[CPNumberRecogniser alloc] init] autorelease];
+    CPNumberRecogniser *rec = [[CPNumberRecogniser alloc] init];
     [rec setRecognisesInts:NO];
     [rec setRecognisesFloats:YES];
     return rec;
@@ -55,7 +55,7 @@
 
 + (id)numberRecogniser
 {
-    CPNumberRecogniser *rec = [[[CPNumberRecogniser alloc] init] autorelease];
+    CPNumberRecogniser *rec = [[CPNumberRecogniser alloc] init];
     [rec setRecognisesInts:YES];
     [rec setRecognisesFloats:YES];
     return rec;

--- a/CoreParse/Tokenisation/Token Recognisers/CPQuotedRecogniser.m
+++ b/CoreParse/Tokenisation/Token Recognisers/CPQuotedRecogniser.m
@@ -31,7 +31,7 @@
 
 + (id)quotedRecogniserWithStartQuote:(NSString *)startQuote endQuote:(NSString *)endQuote escapeSequence:(NSString *)escapeSequence maximumLength:(NSUInteger)maximumLength name:(NSString *)name
 {
-    return [[[CPQuotedRecogniser alloc] initWithStartQuote:startQuote endQuote:endQuote escapeSequence:escapeSequence maximumLength:maximumLength name:name] autorelease];
+    return [[CPQuotedRecogniser alloc] initWithStartQuote:startQuote endQuote:endQuote escapeSequence:escapeSequence maximumLength:maximumLength name:name];
 }
 
 - (id)initWithStartQuote:(NSString *)initStartQuote endQuote:(NSString *)initEndQuote escapeSequence:(NSString *)initEscapeSequence maximumLength:(NSUInteger)initMaximumLength name:(NSString *)initName
@@ -93,17 +93,6 @@
     [aCoder encodeObject:[self name]           forKey:CPQuotedRecogniserNameKey];
 }
 
-- (void)dealloc
-{
-    [startQuote release];
-    [endQuote release];
-    [escapeSequence release];
-    [escapeReplacer release];
-    [name release];
-    
-    [super dealloc];
-}
-
 - (CPToken *)recogniseTokenInString:(NSString *)tokenString currentTokenPosition:(NSUInteger *)tokenPosition
 {
     NSString *(^er)(NSString *tokenStream, NSUInteger *quotePosition) = [self escapeReplacer];
@@ -135,7 +124,7 @@
                 CFStringRef substr = CFStringCreateWithSubstring(kCFAllocatorDefault, (CFStringRef)tokenString, CFRangeMake(searchRange.location, endRange.location - searchRange.location));
                 CFStringAppend(outputString, substr);
                 CFRelease(substr);
-                CPQuotedToken *t = [CPQuotedToken content:(NSString *)outputString quotedWith:startQuote name:[self name]];
+                CPQuotedToken *t = [CPQuotedToken content:(__bridge NSString *)outputString quotedWith:startQuote name:[self name]];
                 CFRelease(outputString);
                 return t;
             }

--- a/CoreParse/Tokenisation/Token Recognisers/CPWhiteSpaceRecogniser.m
+++ b/CoreParse/Tokenisation/Token Recognisers/CPWhiteSpaceRecogniser.m
@@ -23,7 +23,7 @@
 
 + (id)whiteSpaceRecogniser
 {
-    return [[[CPWhiteSpaceRecogniser alloc] init] autorelease];
+    return [[CPWhiteSpaceRecogniser alloc] init];
 }
 
 - (CPToken *)recogniseTokenInString:(NSString *)tokenString currentTokenPosition:(NSUInteger *)tokenPosition

--- a/CoreParse/Tokenisation/Token Types/CPEOFToken.m
+++ b/CoreParse/Tokenisation/Token Types/CPEOFToken.m
@@ -12,7 +12,7 @@
 
 + (id)eof
 {
-    return [[[CPEOFToken alloc] init] autorelease];
+    return [[CPEOFToken alloc] init];
 }
 
 - (NSString *)name

--- a/CoreParse/Tokenisation/Token Types/CPErrorToken.m
+++ b/CoreParse/Tokenisation/Token Types/CPErrorToken.m
@@ -14,7 +14,7 @@
 
 + (id)errorWithMessage:(NSString *)errorMessage
 {
-    return [[[self alloc] initWithMesage:errorMessage] autorelease];
+    return [[self alloc] initWithMesage:errorMessage];
 }
 
 - (id)initWithMesage:(NSString *)initErrorMessage
@@ -27,13 +27,6 @@
     }
     
     return self;
-}
-
-- (void)dealloc
-{
-    [errorMessage release];
-    
-    [super dealloc];
 }
 
 - (NSString *)name

--- a/CoreParse/Tokenisation/Token Types/CPIdentifierToken.m
+++ b/CoreParse/Tokenisation/Token Types/CPIdentifierToken.m
@@ -17,7 +17,7 @@
 
 + (id)tokenWithIdentifier:(NSString *)identifier
 {
-    return [[(CPIdentifierToken *)[CPIdentifierToken alloc] initWithIdentifier:identifier] autorelease];
+    return [(CPIdentifierToken *)[CPIdentifierToken alloc] initWithIdentifier:identifier];
 }
 
 - (id)initWithIdentifier:(NSString *)initIdentifier
@@ -35,13 +35,6 @@
 - (id)init
 {
     return [self initWithIdentifier:@""];
-}
-
-- (void)dealloc
-{
-    [identifier release];
-    
-    [super dealloc];
 }
 
 - (NSString *)description

--- a/CoreParse/Tokenisation/Token Types/CPKeywordToken.m
+++ b/CoreParse/Tokenisation/Token Types/CPKeywordToken.m
@@ -14,7 +14,7 @@
 
 + (id)tokenWithKeyword:(NSString *)keyword
 {
-    return [[[CPKeywordToken alloc] initWithKeyword:keyword] autorelease];
+    return [[CPKeywordToken alloc] initWithKeyword:keyword];
 }
 
 - (id)initWithKeyword:(NSString *)initKeyword
@@ -32,12 +32,6 @@
 - (id)init
 {
     return [self initWithKeyword:@" "];
-}
-
-- (void)dealloc
-{
-    [keyword release];
-    [super dealloc];
 }
 
 - (NSString *)description

--- a/CoreParse/Tokenisation/Token Types/CPNumberToken.m
+++ b/CoreParse/Tokenisation/Token Types/CPNumberToken.m
@@ -14,7 +14,7 @@
 
 + (id)tokenWithNumber:(NSNumber *)number
 {
-    return [[[CPNumberToken alloc] initWithNumber:number] autorelease];
+    return [[CPNumberToken alloc] initWithNumber:number];
 }
 
 - (id)initWithNumber:(NSNumber *)initNumber
@@ -32,12 +32,6 @@
 - (id)init
 {
     return [self initWithNumber:[NSNumber numberWithInteger:0]];
-}
-
-- (void)dealloc
-{
-    [number release];
-    [super dealloc];
 }
 
 - (NSString *)description

--- a/CoreParse/Tokenisation/Token Types/CPQuotedToken.m
+++ b/CoreParse/Tokenisation/Token Types/CPQuotedToken.m
@@ -22,7 +22,7 @@
 
 + (id)content:(NSString *)content quotedWith:(NSString *)quoteType name:(NSString *)name
 {
-    return [[[CPQuotedToken alloc] initWithContent:content quoteType:quoteType name:name] autorelease];
+    return [[CPQuotedToken alloc] initWithContent:content quoteType:quoteType name:name];
 }
 
 - (id)initWithContent:(NSString *)initContent quoteType:(NSString *)initQuoteType name:(NSString *)initName
@@ -42,15 +42,6 @@
 - (id)init
 {
     return [self initWithContent:@"" quoteType:@"" name:@""];
-}
-
-- (void)dealloc
-{
-    [content release];
-    [quoteType release];
-    [name release];
-    
-    [super dealloc];
 }
 
 - (NSString *)description

--- a/CoreParse/Tokenisation/Token Types/CPWhiteSpaceToken.m
+++ b/CoreParse/Tokenisation/Token Types/CPWhiteSpaceToken.m
@@ -14,7 +14,7 @@
 
 + (id)whiteSpace:(NSString *)whiteSpace
 {
-    return [[[CPWhiteSpaceToken alloc] initWithWhiteSpace:whiteSpace] autorelease];
+    return [[CPWhiteSpaceToken alloc] initWithWhiteSpace:whiteSpace];
 }
 
 - (id)initWithWhiteSpace:(NSString *)initWhiteSpace
@@ -32,13 +32,6 @@
 - (id)init
 {
     return [self initWithWhiteSpace:@""];
-}
-
-- (void)dealloc
-{
-    [whiteSpace release];
-    
-    [super dealloc];
 }
 
 - (NSString *)name

--- a/CoreParseTests/CPTestMapCSSTokenisingDelegate.m
+++ b/CoreParseTests/CPTestMapCSSTokenisingDelegate.m
@@ -22,17 +22,10 @@
     
     if (nil != self)
     {
-        symbolsSet = [[NSCharacterSet characterSetWithCharactersInString:@"*[]{}().,;@|-!=<>:!"] retain];
+        symbolsSet = [NSCharacterSet characterSetWithCharactersInString:@"*[]{}().,;@|-!=<>:!"];
     }
     
     return self;
-}
-
-- (void)dealloc
-{
-    [symbolsSet release];
-    
-    [super dealloc];
 }
 
 - (BOOL)tokeniser:(CPTokeniser *)tokeniser shouldConsumeToken:(CPToken *)token

--- a/CoreParseTests/CoreParseTests.m
+++ b/CoreParseTests/CoreParseTests.m
@@ -83,7 +83,7 @@
     [mapCssTokeniser addTokenRecogniser:[CPQuotedRecogniser quotedRecogniserWithStartQuote:@"'"  endQuote:@"'"  escapeSequence:@"\\" name:@"String"]];
     [mapCssTokeniser addTokenRecogniser:[CPQuotedRecogniser quotedRecogniserWithStartQuote:@"\"" endQuote:@"\"" escapeSequence:@"\\" name:@"String"]];
     [mapCssTokeniser addTokenRecogniser:[CPIdentifierRecogniser identifierRecogniserWithInitialCharacters:initialIdCharacters identifierCharacters:identifierCharacters]];
-    [mapCssTokeniser setDelegate:[[[CPTestMapCSSTokenisingDelegate alloc] init] autorelease]];
+    [mapCssTokeniser setDelegate:[[CPTestMapCSSTokenisingDelegate alloc] init]];
     
     mapCssInput = @"node[highway=\"trunk\"]"
     @"{"
@@ -124,13 +124,11 @@
 
 - (void)tearDownMapCSS
 {
-    [mapCssParser release];
-    [mapCssTokeniser release];
 }
 
 - (void)testKeywordTokeniser
 {
-    CPTokeniser *tokeniser = [[[CPTokeniser alloc] init] autorelease];
+    CPTokeniser *tokeniser = [[CPTokeniser alloc] init];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@"{"]];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@"}"]];
     CPTokenStream *tokenStream = [tokeniser tokenise:@"{}"];
@@ -140,7 +138,7 @@
 
 - (void)testIntegerTokeniser
 {
-    CPTokeniser *tokeniser = [[[CPTokeniser alloc] init] autorelease];
+    CPTokeniser *tokeniser = [[CPTokeniser alloc] init];
     [tokeniser addTokenRecogniser:[CPNumberRecogniser integerRecogniser]];
     CPTokenStream *tokenStream = [tokeniser tokenise:@"1234"];
     CPTokenStream *expectedTokenStream = [CPTokenStream tokenStreamWithTokens:[NSArray arrayWithObjects:[CPNumberToken tokenWithNumber:[NSNumber numberWithInteger:1234]], [CPEOFToken eof], nil]];
@@ -153,7 +151,7 @@
 
 - (void)testFloatTokeniser
 {
-    CPTokeniser *tokeniser = [[[CPTokeniser alloc] init] autorelease];
+    CPTokeniser *tokeniser = [[CPTokeniser alloc] init];
     [tokeniser addTokenRecogniser:[CPNumberRecogniser floatRecogniser]];
     CPTokenStream *tokenStream = [tokeniser tokenise:@"1234.5678"];
     CPTokenStream *expectedTokenStream = [CPTokenStream tokenStreamWithTokens:[NSArray arrayWithObjects:[CPNumberToken tokenWithNumber:[NSNumber numberWithDouble:1234.5678]], [CPEOFToken eof], nil]];
@@ -166,7 +164,7 @@
 
 - (void)testNumberTokeniser
 {
-    CPTokeniser *tokeniser = [[[CPTokeniser alloc] init] autorelease];
+    CPTokeniser *tokeniser = [[CPTokeniser alloc] init];
     [tokeniser addTokenRecogniser:[CPNumberRecogniser numberRecogniser]];
 
     CPTokenStream *tokenStream = [tokeniser tokenise:@"1234.5678"];
@@ -180,7 +178,7 @@
 
 - (void)testWhiteSpaceTokeniser
 {
-    CPTokeniser *tokeniser = [[[CPTokeniser alloc] init] autorelease];
+    CPTokeniser *tokeniser = [[CPTokeniser alloc] init];
     [tokeniser addTokenRecogniser:[CPNumberRecogniser numberRecogniser]];
     [tokeniser addTokenRecogniser:[CPWhiteSpaceRecogniser whiteSpaceRecogniser]];
     CPTokenStream *tokenStream = [tokeniser tokenise:@"12.34 56.78\t90"];
@@ -193,7 +191,7 @@
 
 - (void)testIdentifierTokeniser
 {
-    CPTokeniser *tokeniser = [[[CPTokeniser alloc] init] autorelease];
+    CPTokeniser *tokeniser = [[CPTokeniser alloc] init];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@"long"]];
     [tokeniser addTokenRecogniser:[CPIdentifierRecogniser identifierRecogniser]];
     [tokeniser addTokenRecogniser:[CPWhiteSpaceRecogniser whiteSpaceRecogniser]];
@@ -206,7 +204,7 @@
                                                                                [CPIdentifierToken tokenWithIdentifier:@"_spam59e_53"], [CPEOFToken eof], nil]];
     STAssertEqualObjects(tokenStream, expectedTokenStream, @"Failed to tokenise identifiers space correctly", nil);
     
-    tokeniser = [[[CPTokeniser alloc] init] autorelease];
+    tokeniser = [[CPTokeniser alloc] init];
     [tokeniser addTokenRecogniser:[CPIdentifierRecogniser identifierRecogniserWithInitialCharacters:[NSCharacterSet characterSetWithCharactersInString:@"abc"]
                                                                                identifierCharacters:[NSCharacterSet characterSetWithCharactersInString:@"def"]]];
     [tokeniser addTokenRecogniser:[CPWhiteSpaceRecogniser whiteSpaceRecogniser]];
@@ -220,7 +218,7 @@
 
 - (void)testQuotedTokeniser
 {
-    CPTokeniser *tokeniser = [[[CPTokeniser alloc] init] autorelease];
+    CPTokeniser *tokeniser = [[CPTokeniser alloc] init];
     [tokeniser addTokenRecogniser:[CPQuotedRecogniser quotedRecogniserWithStartQuote:@"/*" endQuote:@"*/" name:@"Comment"]];
     CPTokenStream *tokenStream = [tokeniser tokenise:@"/* abcde ghi */"];
     CPTokenStream *expectdTokenStream = [CPTokenStream tokenStreamWithTokens:[NSArray arrayWithObjects:[CPQuotedToken content:@" abcde ghi " quotedWith:@"/*" name:@"Comment"], [CPEOFToken eof], nil]];
@@ -239,7 +237,7 @@
     expectdTokenStream = [CPTokenStream tokenStreamWithTokens:[NSArray arrayWithObjects:[CPQuotedToken content:@"def\\" quotedWith:@"\"" name:@"String"], [CPEOFToken eof], nil]];
     STAssertEqualObjects(tokenStream, expectdTokenStream, @"Failed to tokenise string with backslash in it", nil);
 
-    tokeniser = [[[CPTokeniser alloc] init] autorelease];
+    tokeniser = [[CPTokeniser alloc] init];
     CPQuotedRecogniser *rec = [CPQuotedRecogniser quotedRecogniserWithStartQuote:@"\"" endQuote:@"\"" escapeSequence:@"\\" name:@"String"];
     [rec setEscapeReplacer:^ NSString * (NSString *str, NSUInteger *loc)
      {
@@ -273,7 +271,7 @@
     expectdTokenStream = [CPTokenStream tokenStreamWithTokens:[NSArray arrayWithObjects:[CPQuotedToken content:@"\n\r\f" quotedWith:@"\"" name:@"String"], [CPEOFToken eof], nil]];
     STAssertEqualObjects(tokenStream, expectdTokenStream, @"Failed to correctly tokenise string with recognised escape chars", nil);
     
-    tokeniser = [[[CPTokeniser alloc] init] autorelease];
+    tokeniser = [[CPTokeniser alloc] init];
     [tokeniser addTokenRecogniser:[CPQuotedRecogniser quotedRecogniserWithStartQuote:@"'" endQuote:@"'" escapeSequence:nil maximumLength:1 name:@"Character"]];
     tokenStream = [tokeniser tokenise:@"'a''bc'"];
     expectdTokenStream = [CPTokenStream tokenStreamWithTokens:[NSArray arrayWithObjects:[CPQuotedToken content:@"a" quotedWith:@"'" name:@"Character"], [CPErrorToken errorWithMessage:nil], nil]];
@@ -282,13 +280,13 @@
 
 - (void)testTokeniserError
 {
-    CPTokeniser *tokeniser = [[[CPTokeniser alloc] init] autorelease];
+    CPTokeniser *tokeniser = [[CPTokeniser alloc] init];
     [tokeniser addTokenRecogniser:[CPQuotedRecogniser quotedRecogniserWithStartQuote:@"/*" endQuote:@"*/" name:@"Comment"]];
     CPTokenStream *tokenStream = [tokeniser tokenise:@"/* abcde ghi */ abc /* def */"];
     CPTokenStream *expectedTokenStream = [CPTokenStream tokenStreamWithTokens:[NSArray arrayWithObjects:[CPQuotedToken content:@" abcde ghi " quotedWith:@"/*" name:@"Comment"], [CPErrorToken errorWithMessage:nil], nil]];
     STAssertEqualObjects(tokenStream, expectedTokenStream, @"Inserting error token and bailing failed", nil);
     
-    [tokeniser setDelegate:[[[CPTestErrorHandlingDelegate alloc] init] autorelease]];
+    [tokeniser setDelegate:[[CPTestErrorHandlingDelegate alloc] init]];
     tokenStream = [tokeniser tokenise:@"/* abcde ghi */ abc /* def */"];
     expectedTokenStream = [CPTokenStream tokenStreamWithTokens:[NSArray arrayWithObjects:[CPQuotedToken content:@" abcde ghi " quotedWith:@"/*" name:@"Comment"], [CPErrorToken errorWithMessage:nil], [CPQuotedToken content:@" def " quotedWith:@"/*" name:@"Comment"], [CPEOFToken eof], nil]];
     STAssertEqualObjects(tokenStream, expectedTokenStream, @"Inserting error token and continuing according to delegate failed.", nil);
@@ -296,7 +294,7 @@
 
 - (void)testTokenLineColumnNumbers
 {
-    CPTokeniser *tokeniser = [[[CPTokeniser alloc] init] autorelease];
+    CPTokeniser *tokeniser = [[CPTokeniser alloc] init];
     [tokeniser addTokenRecogniser:[CPQuotedRecogniser quotedRecogniserWithStartQuote:@"/*" endQuote:@"*/" name:@"Comment"]];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@"long"]];
     [tokeniser addTokenRecogniser:[CPIdentifierRecogniser identifierRecogniser]];
@@ -361,14 +359,14 @@
 
 - (void)testSLR
 {
-    CPTokeniser *tokeniser = [[[CPTokeniser alloc] init] autorelease];
+    CPTokeniser *tokeniser = [[CPTokeniser alloc] init];
     [tokeniser addTokenRecogniser:[CPNumberRecogniser integerRecogniser]];
     [tokeniser addTokenRecogniser:[CPWhiteSpaceRecogniser whiteSpaceRecogniser]];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@"+"]];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@"*"]];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@"("]];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@")"]];
-    [tokeniser setDelegate:[[[CPTestWhiteSpaceIgnoringDelegate alloc] init] autorelease]];
+    [tokeniser setDelegate:[[CPTestWhiteSpaceIgnoringDelegate alloc] init]];
     CPTokenStream *tokenStream = [tokeniser tokenise:@"5 + (2 * 5 + 9) * 8"];
     
     CPRule *tE = [CPRule ruleWithName:@"e" rightHandSideElements:[NSArray arrayWithObject:[CPGrammarSymbol nonTerminalWithName:@"t"]] tag:0];
@@ -379,7 +377,7 @@
     CPRule *pF = [CPRule ruleWithName:@"f" rightHandSideElements:[NSArray arrayWithObjects:[CPGrammarSymbol terminalWithName:@"("], [CPGrammarSymbol nonTerminalWithName:@"e"], [CPGrammarSymbol terminalWithName:@")"], nil] tag:5];
     CPGrammar *grammar = [CPGrammar grammarWithStart:@"e" rules:[NSArray arrayWithObjects:tE, aE, fT, mT, iF, pF, nil]];
     CPSLRParser *parser = [CPSLRParser parserWithGrammar:grammar];
-    [parser setDelegate:[[[CPTestEvaluatorDelegate alloc] init] autorelease]];
+    [parser setDelegate:[[CPTestEvaluatorDelegate alloc] init]];
     NSNumber *result = [parser parse:tokenStream];
     
     STAssertEquals([result intValue], 157, @"Parsed expression had incorrect value when using SLR parser", nil);
@@ -387,14 +385,14 @@
 
 - (void)testLR1
 {
-    CPTokeniser *tokeniser = [[[CPTokeniser alloc] init] autorelease];
+    CPTokeniser *tokeniser = [[CPTokeniser alloc] init];
     [tokeniser addTokenRecogniser:[CPNumberRecogniser integerRecogniser]];
     [tokeniser addTokenRecogniser:[CPWhiteSpaceRecogniser whiteSpaceRecogniser]];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@"+"]];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@"*"]];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@"("]];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@")"]];
-    [tokeniser setDelegate:[[[CPTestWhiteSpaceIgnoringDelegate alloc] init] autorelease]];
+    [tokeniser setDelegate:[[CPTestWhiteSpaceIgnoringDelegate alloc] init]];
     CPTokenStream *tokenStream = [tokeniser tokenise:@"5 + (2 * 5 + 9) * 8"];
     
     CPRule *tE = [CPRule ruleWithName:@"e" rightHandSideElements:[NSArray arrayWithObject:[CPGrammarSymbol nonTerminalWithName:@"t"]] tag:0];
@@ -405,12 +403,12 @@
     CPRule *pF = [CPRule ruleWithName:@"f" rightHandSideElements:[NSArray arrayWithObjects:[CPGrammarSymbol terminalWithName:@"("], [CPGrammarSymbol nonTerminalWithName:@"e"], [CPGrammarSymbol terminalWithName:@")"], nil] tag:5];
     CPGrammar *grammar = [CPGrammar grammarWithStart:@"e" rules:[NSArray arrayWithObjects:tE, aE, fT, mT, iF, pF, nil]];
     CPLR1Parser *parser = [CPLR1Parser parserWithGrammar:grammar];
-    [parser setDelegate:[[[CPTestEvaluatorDelegate alloc] init] autorelease]];
+    [parser setDelegate:[[CPTestEvaluatorDelegate alloc] init]];
     NSNumber *result = [parser parse:tokenStream];
     
     STAssertEquals([result intValue], 157, @"Parsed expression had incorrect value when using LR(1) parser", nil);
     
-    tokeniser = [[[CPTokeniser alloc] init] autorelease];
+    tokeniser = [[CPTokeniser alloc] init];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@"a"]];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@"b"]];
     tokenStream = [tokeniser tokenise:@"aaabab"];
@@ -432,12 +430,12 @@
 
 - (void)testLALR1
 {
-    CPTokeniser *tokeniser = [[[CPTokeniser alloc] init] autorelease];
+    CPTokeniser *tokeniser = [[CPTokeniser alloc] init];
     [tokeniser addTokenRecogniser:[CPNumberRecogniser integerRecogniser]];
     [tokeniser addTokenRecogniser:[CPWhiteSpaceRecogniser whiteSpaceRecogniser]];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@"="]];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@"*"]];
-    [tokeniser setDelegate:[[[CPTestWhiteSpaceIgnoringDelegate alloc] init] autorelease]];
+    [tokeniser setDelegate:[[CPTestWhiteSpaceIgnoringDelegate alloc] init]];
     CPTokenStream *tokenStream = [tokeniser tokenise:@"*10 = 5"];
     
     CPRule *sL = [CPRule ruleWithName:@"s" rightHandSideElements:[NSArray arrayWithObjects:[CPGrammarSymbol nonTerminalWithName:@"l"], [CPGrammarSymbol terminalWithName:@"="], [CPGrammarSymbol nonTerminalWithName:@"r"], nil]];
@@ -458,14 +456,14 @@
     
     STAssertEqualObjects(tree, wholeTree, @"Parsing LALR(1) grammar failed", nil);
     
-    tokeniser = [[[CPTokeniser alloc] init] autorelease];
+    tokeniser = [[CPTokeniser alloc] init];
     [tokeniser addTokenRecogniser:[CPNumberRecogniser integerRecogniser]];
     [tokeniser addTokenRecogniser:[CPWhiteSpaceRecogniser whiteSpaceRecogniser]];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@"+"]];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@"*"]];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@"("]];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@")"]];
-    [tokeniser setDelegate:[[[CPTestWhiteSpaceIgnoringDelegate alloc] init] autorelease]];
+    [tokeniser setDelegate:[[CPTestWhiteSpaceIgnoringDelegate alloc] init]];
     tokenStream = [tokeniser tokenise:@"5 + (2 * 5 + 9) * 8"];
     
     CPRule *tE = [CPRule ruleWithName:@"e" rightHandSideElements:[NSArray arrayWithObject:[CPGrammarSymbol nonTerminalWithName:@"t"]] tag:0];
@@ -476,12 +474,12 @@
     CPRule *pF = [CPRule ruleWithName:@"f" rightHandSideElements:[NSArray arrayWithObjects:[CPGrammarSymbol terminalWithName:@"("], [CPGrammarSymbol nonTerminalWithName:@"e"], [CPGrammarSymbol terminalWithName:@")"], nil] tag:5];
     grammar = [CPGrammar grammarWithStart:@"e" rules:[NSArray arrayWithObjects:tE, aE, fT, mT, iF, pF, nil]];
     parser = [CPLALR1Parser parserWithGrammar:grammar];
-    [parser setDelegate:[[[CPTestEvaluatorDelegate alloc] init] autorelease]];
+    [parser setDelegate:[[CPTestEvaluatorDelegate alloc] init]];
     NSNumber *result = [parser parse:tokenStream];
     
     STAssertEquals([result intValue], 157, @"Parsed expression had incorrect value when using LALR(1) parser", nil);
     
-    tokeniser = [[[CPTokeniser alloc] init] autorelease];
+    tokeniser = [[CPTokeniser alloc] init];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@"a"]];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@"b"]];
     tokenStream = [tokeniser tokenise:@"aaabab"];
@@ -503,14 +501,14 @@
 
 - (void)testBNFGrammarGeneration
 {
-    CPTokeniser *tokeniser = [[[CPTokeniser alloc] init] autorelease];
+    CPTokeniser *tokeniser = [[CPTokeniser alloc] init];
     [tokeniser addTokenRecogniser:[CPNumberRecogniser integerRecogniser]];
     [tokeniser addTokenRecogniser:[CPWhiteSpaceRecogniser whiteSpaceRecogniser]];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@"+"]];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@"*"]];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@"("]];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@")"]];
-    [tokeniser setDelegate:[[[CPTestWhiteSpaceIgnoringDelegate alloc] init] autorelease]];
+    [tokeniser setDelegate:[[CPTestWhiteSpaceIgnoringDelegate alloc] init]];
     CPTokenStream *tokenStream = [tokeniser tokenise:@"5 + (2 * 5 + 9) * 8"];
     
     CPRule *e1 = [CPRule ruleWithName:@"e" rightHandSideElements:[NSArray arrayWithObjects:[CPGrammarSymbol nonTerminalWithName:@"t"], nil] tag:0];
@@ -532,10 +530,10 @@
         @"5 f ::= '(' <e> ')';";
     CPGrammar *grammar1 = [CPGrammar grammarWithStart:@"e" backusNaurForm:testGrammar error:NULL];
     
-    STAssertEqualObjects(grammar, grammar1, @"Crating grammar from BNF failed", nil);
+    STAssertEqualObjects(grammar, grammar1, @"Creating grammar from BNF failed", nil);
         
     CPParser *parser = [CPSLRParser parserWithGrammar:grammar];
-    [parser setDelegate:[[[CPTestEvaluatorDelegate alloc] init] autorelease]];
+    [parser setDelegate:[[CPTestEvaluatorDelegate alloc] init]];
     NSNumber *result = [parser parse:tokenStream];
     
     STAssertEquals([result intValue], 157, @"Parsed expression had incorrect value", nil);
@@ -595,7 +593,7 @@
 - (void)testParallelParsing
 {
     [self setUpMapCSS];
-    CPTokenStream *stream = [[[CPTokenStream alloc] init] autorelease];
+    CPTokenStream *stream = [[CPTokenStream alloc] init];
     [NSThread detachNewThreadSelector:@selector(runMapCSSTokeniser:) toTarget:self withObject:stream];
     CPSyntaxTree *tree1 = [mapCssParser parse:stream];
     CPSyntaxTree *tree2 = [mapCssParser parse:[mapCssTokeniser tokenise:mapCssInput]];
@@ -607,11 +605,11 @@
 
 - (void)testParseResultParsing
 {
-    CPTokeniser *tokeniser = [[[CPTokeniser alloc] init] autorelease];
+    CPTokeniser *tokeniser = [[CPTokeniser alloc] init];
     [tokeniser addTokenRecogniser:[CPNumberRecogniser integerRecogniser]];
     [tokeniser addTokenRecogniser:[CPWhiteSpaceRecogniser whiteSpaceRecogniser]];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@"+"]];
-    [tokeniser setDelegate:[[[CPTestWhiteSpaceIgnoringDelegate alloc] init] autorelease]];
+    [tokeniser setDelegate:[[CPTestWhiteSpaceIgnoringDelegate alloc] init]];
     CPTokenStream *tokenStream = [tokeniser tokenise:@"5 + 9 + 2 + 7"];
     
     NSString *testGrammar =
@@ -634,7 +632,7 @@
 
 - (void)testJSONParsing
 {
-    CPJSONParser *jsonParser = [[[CPJSONParser alloc] init] autorelease];
+    CPJSONParser *jsonParser = [[CPJSONParser alloc] init];
     id<NSObject> result = [jsonParser parse:@"{\"a\":\"b\", \"c\":true, \"d\":5.93, \"e\":[1,2,3], \"f\":null}"];
     
     NSDictionary *expectedResult = [NSDictionary dictionaryWithObjectsAndKeys:
@@ -654,7 +652,7 @@
 - (void)testEBNFStar
 {
     NSError *err = nil;
-    CPTokeniser *tokeniser = [[[CPTokeniser alloc] init] autorelease];
+    CPTokeniser *tokeniser = [[CPTokeniser alloc] init];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@"a"]];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@"b"]];
     CPTokenStream *tokenStream = [tokeniser tokenise:@"baaa"];
@@ -679,7 +677,7 @@
 - (void)testEBNFTaggedStar
 {
     NSError *err = nil;
-    CPTokeniser *tokeniser = [[[CPTokeniser alloc] init] autorelease];
+    CPTokeniser *tokeniser = [[CPTokeniser alloc] init];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@"a"]];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@"b"]];
     CPTokenStream *tokenStream = [tokeniser tokenise:@"baaa"];
@@ -706,7 +704,7 @@
 - (void)testEBNFPlus
 {
     NSError *err = nil;
-    CPTokeniser *tokeniser = [[[CPTokeniser alloc] init] autorelease];
+    CPTokeniser *tokeniser = [[CPTokeniser alloc] init];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@"a"]];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@"b"]];
     CPTokenStream *tokenStream = [tokeniser tokenise:@"baaa"];
@@ -730,7 +728,7 @@
 - (void)testEBNFQuery
 {
     NSError *err = nil;
-    CPTokeniser *tokeniser = [[[CPTokeniser alloc] init] autorelease];
+    CPTokeniser *tokeniser = [[CPTokeniser alloc] init];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@"a"]];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@"b"]];
     CPTokenStream *tokenStream = [tokeniser tokenise:@"baaa"];
@@ -754,7 +752,7 @@
 - (void)testEBNFParentheses
 {
     NSError *err = nil;
-    CPTokeniser *tokeniser = [[[CPTokeniser alloc] init] autorelease];
+    CPTokeniser *tokeniser = [[CPTokeniser alloc] init];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@"a"]];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@"b"]];
     CPTokenStream *tokenStream = [tokeniser tokenise:@"baaab"];
@@ -778,7 +776,7 @@
 - (void)testEBNFParenthesesWithOr
 {
     NSError *err = nil;
-    CPTokeniser *tokeniser = [[[CPTokeniser alloc] init] autorelease];
+    CPTokeniser *tokeniser = [[CPTokeniser alloc] init];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@"a"]];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@"b"]];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@"c"]];
@@ -839,7 +837,7 @@
 
 - (void)testParserErrors
 {
-    CPTokeniser *tokeniser = [[[CPTokeniser alloc] init] autorelease];
+    CPTokeniser *tokeniser = [[CPTokeniser alloc] init];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@"a"]];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@"b"]];
     NSString *starGrammarString = @"A ::= 'b''a'*;";
@@ -848,7 +846,7 @@
     
     CPTokenStream *faultyTokenStream = [tokeniser tokenise:@"baab"];
     CPTokenStream *corretTokenStream = [tokeniser tokenise:@"baa"];
-    CPTestErrorHandlingDelegate *errorDelegate = [[[CPTestErrorHandlingDelegate alloc] init] autorelease];
+    CPTestErrorHandlingDelegate *errorDelegate = [[CPTestErrorHandlingDelegate alloc] init];
     [starParser setDelegate:errorDelegate];
     CPSyntaxTree *faultyTree = [starParser parse:faultyTokenStream];
     STAssertTrue([errorDelegate hasEncounteredError], @"Error did not get reported to delegate", nil);
@@ -859,14 +857,14 @@
 
 - (void)testErrorRecovery
 {
-    CPTokeniser *tokeniser = [[[CPTokeniser alloc] init] autorelease];
+    CPTokeniser *tokeniser = [[CPTokeniser alloc] init];
     [tokeniser addTokenRecogniser:[CPNumberRecogniser integerRecogniser]];
     [tokeniser addTokenRecogniser:[CPWhiteSpaceRecogniser whiteSpaceRecogniser]];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@"+"]];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@"*"]];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@"("]];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@")"]];
-    [tokeniser setDelegate:[[[CPTestWhiteSpaceIgnoringDelegate alloc] init] autorelease]];
+    [tokeniser setDelegate:[[CPTestWhiteSpaceIgnoringDelegate alloc] init]];
     CPTokenStream *tokenStream = [tokeniser tokenise:@"5 + + (2 * error + 3) * 8"];
     
     NSString *testGrammar =
@@ -883,7 +881,7 @@
     CPGrammar *grammar = [CPGrammar grammarWithStart:@"e" backusNaurForm:testGrammar error:NULL];
     
     CPParser *parser = [CPSLRParser parserWithGrammar:grammar];
-    [parser setDelegate:[[[CPTestErrorEvaluatorDelegate alloc] init] autorelease]];
+    [parser setDelegate:[[CPTestErrorEvaluatorDelegate alloc] init]];
     NSNumber *result = [parser parse:tokenStream];
     
     STAssertEquals([result intValue], 45, @"Parsed expression had incorrect value", nil);
@@ -891,11 +889,11 @@
 
 - (void)testConformsToProtocol
 {
-    CPTokeniser *tokeniser = [[[CPTokeniser alloc] init] autorelease];
+    CPTokeniser *tokeniser = [[CPTokeniser alloc] init];
     [tokeniser addTokenRecogniser:[CPNumberRecogniser integerRecogniser]];
     [tokeniser addTokenRecogniser:[CPWhiteSpaceRecogniser whiteSpaceRecogniser]];
     [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@"+"]];
-    [tokeniser setDelegate:[[[CPTestWhiteSpaceIgnoringDelegate alloc] init] autorelease]];
+    [tokeniser setDelegate:[[CPTestWhiteSpaceIgnoringDelegate alloc] init]];
     CPTokenStream *tokenStream = [tokeniser tokenise:@"5 + 9 + 2 + 7"];
     
     NSString *testGrammar =


### PR DESCRIPTION
This pull request makes the code base compatible with ARC. This makes it much easier to integrate the source code directly into modern projects without having to mess with static libraries or frameworks.

The changes were mostly mechanical. The one major change was to get rid of the mallocs and use regular NSArrays, since I could not find a way to make ARC happy about a malloc'ed array that contained objects. If the performance in the shift reduce or goto tables suffers as a result, we could find a way to optimize this again.

The other minor change was to use NSString's rangeOfCharacterFromSet instead of CFStringFindCharacterFromSet, as the bridge was causing issues.

All unit tests pass.
