### PR TITLE
Namespace function method, rename the map: to cp_map: to avoid conflicts

### DIFF
--- a/CoreParse/Grammar/CPGrammarInternal.m
+++ b/CoreParse/Grammar/CPGrammarInternal.m
@@ -84,7 +84,7 @@
              {
                  return [symbol isEqualToGrammarSymbol:[item nextSymbol]];
              }]
-            map:^ id (CPItem *item)
+            cp_map:^ id (CPItem *item)
             {
                 return [item itemByMovingDotRight];
             }];
@@ -101,7 +101,7 @@
     {
         NSSet *kernel = [processingQueue objectAtIndex:0];
         NSSet *itemSet = [self lr0Closure:kernel];
-        NSSet *validNexts = [itemSet map:^ id (CPItem *item) { return [item nextSymbol]; }];
+        NSSet *validNexts = [itemSet cp_map:^ id (CPItem *item) { return [item nextSymbol]; }];
         
         for (CPGrammarSymbol *s in validNexts)
         {
@@ -163,7 +163,7 @@
              {
                  return [symbol isEqualToGrammarSymbol:[item nextSymbol]];
              }]
-            map:^ id (CPItem *item)
+            cp_map:^ id (CPItem *item)
             {
                 return [item itemByMovingDotRight];
             }];

--- a/CoreParse/NSArray+Functional.h
+++ b/CoreParse/NSArray+Functional.h
@@ -10,6 +10,6 @@
 
 @interface NSArray (Functional)
 
-- (NSArray *)map:(id(^)(id obj))block;
+- (NSArray *)cp_map:(id(^)(id obj))block;
 
 @end

--- a/CoreParse/NSArray+Functional.m
+++ b/CoreParse/NSArray+Functional.m
@@ -10,7 +10,7 @@
 
 @implementation NSArray (Functional)
 
-- (NSArray *)map:(id(^)(id obj))block
+- (NSArray *)cp_map:(id(^)(id obj))block
 {
     NSUInteger c = [self count];
     id *resultingObjects = malloc(c * sizeof(id));

--- a/CoreParse/NSSetFunctional.h
+++ b/CoreParse/NSSetFunctional.h
@@ -11,6 +11,6 @@
 
 @interface NSSet(Functional)
 
-- (NSSet *)map:(id(^)(id obj))block;
+- (NSSet *)cp_map:(id(^)(id obj))block;
 
 @end

--- a/CoreParse/NSSetFunctional.m
+++ b/CoreParse/NSSetFunctional.m
@@ -11,7 +11,7 @@
 
 @implementation NSSet(Functional)
 
-- (NSSet *)map:(id(^)(id obj))block
+- (NSSet *)cp_map:(id(^)(id obj))block
 {
     NSUInteger c = [self count];
     id *resultingObjects = malloc(c * sizeof(id));

--- a/CoreParse/Parsers/CPShiftReduceParsers/CPLALR1Parser.m
+++ b/CoreParse/Parsers/CPShiftReduceParsers/CPLALR1Parser.m
@@ -30,7 +30,7 @@
 {
     CPGrammar *aug = [[self grammar] augmentedGrammar];
     NSArray *kernels = [self kernelsForGrammar:aug];
-    NSArray *lr0Kernels = [kernels map:^ NSSet * (NSSet *s) { return [s map:^ id (CPLR1Item *i) { return [CPItem itemWithRule:[i rule] position:[i position]]; }]; }];
+    NSArray *lr0Kernels = [kernels cp_map:^ NSSet * (NSSet *s) { return [s cp_map:^ id (CPLR1Item *i) { return [CPItem itemWithRule:[i rule] position:[i position]]; }]; }];
     NSUInteger itemCount = [kernels count];
     NSArray *allNonTerminalNames = [[self grammar] allNonTerminalNames];
     NSString *startSymbol = [aug start];
@@ -73,7 +73,7 @@
                     else if ([next isTerminal])
                     {
                         NSSet *g = [aug lr0GotoKernelWithItems:itemsSet symbol:next];
-                        NSSet *lr0G = [g map:^ id (CPLR1Item *i) { return [CPItem itemWithRule:[i rule] position:[i position]]; }];
+                        NSSet *lr0G = [g cp_map:^ id (CPLR1Item *i) { return [CPItem itemWithRule:[i rule] position:[i position]]; }];
                         NSUInteger indx = 0;
                         NSUInteger ix = NSNotFound;
                         for (NSSet *lr0Kernel in lr0Kernels)
@@ -98,7 +98,7 @@
             for (NSString *nonTerminalName in allNonTerminalNames)
             {
                 NSSet *g = [aug lr0GotoKernelWithItems:itemsSet symbol:[CPGrammarSymbol nonTerminalWithName:nonTerminalName]];
-                NSSet *lr0G = [g map:^ id (CPLR1Item *i) { return [CPItem itemWithRule:[i rule] position:[i position]]; }];
+                NSSet *lr0G = [g cp_map:^ id (CPLR1Item *i) { return [CPItem itemWithRule:[i rule] position:[i position]]; }];
                 NSUInteger indx = 0;
                 NSUInteger gotoIndex = NSNotFound;
                 for (NSSet *lr0Kernel in lr0Kernels)

--- a/CoreParse/Parsers/CPShiftReduceParsers/CPLR1Parser.m
+++ b/CoreParse/Parsers/CPShiftReduceParsers/CPLR1Parser.m
@@ -104,7 +104,7 @@
     {
         NSSet *kernels = [processingQueue objectAtIndex:0];
         NSSet *itemSet = [aug lr1Closure:kernels];
-        NSSet *validNexts = [itemSet map:^ id (CPItem *item)
+        NSSet *validNexts = [itemSet cp_map:^ id (CPItem *item)
                              {
                                  return [item nextSymbol];
                              }];


### PR DESCRIPTION
This PR rename the method `map:` to `cp_map:`. This is a good idea as `map:` is a rather general name and as a framework it is probably best not to use it without namespace. 
