### PR TITLE
Added tokeniserWillFinish:stream method to CPTokeniserDelegate protocol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/.DS_Store
+
+/CoreParse.xcodeproj/xcuserdata/
+
+/CoreParse.xcodeproj/project.xcworkspace/xcuserdata/

--- a/CoreParse.xcodeproj/project.pbxproj
+++ b/CoreParse.xcodeproj/project.pbxproj
@@ -174,6 +174,7 @@
 		5419721D188F9A54004240B4 /* CPRegexpRecogniserTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 5419721C188F9A54004240B4 /* CPRegexpRecogniserTest.m */; };
 		DA2B1DF81566B704002FDBD7 /* CPSTAssertionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DA2B1DF71566B704002FDBD7 /* CPSTAssertionsTests.m */; };
 		DA2B1DF91566B704002FDBD7 /* CPSTAssertionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DA2B1DF71566B704002FDBD7 /* CPSTAssertionsTests.m */; };
+		DC3E9BEF191DBAC800F6023C /* CPWillFinishDelegateTest.m in Sources */ = {isa = PBXBuildFile; fileRef = DC3E9BEE191DBAC800F6023C /* CPWillFinishDelegateTest.m */; };
 		EA5FF42E1884CC6600BEEF03 /* CPTestErrorEvaluatorDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F893A2214DEF40D00316FF7 /* CPTestErrorEvaluatorDelegate.m */; };
 		EA5FF42F1884CC7100BEEF03 /* CPTestErrorHandlingDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FA68DA414DE9D3D005519B9 /* CPTestErrorHandlingDelegate.m */; };
 		EA5FF4301884FFDC00BEEF03 /* Expression2.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FA4386C162F515C00B92704 /* Expression2.m */; };
@@ -327,6 +328,7 @@
 		DA2B1DF41566B311002FDBD7 /* CPSenTestKitAssertions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CPSenTestKitAssertions.h; sourceTree = "<group>"; };
 		DA2B1DF61566B704002FDBD7 /* CPSTAssertionsTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CPSTAssertionsTests.h; sourceTree = "<group>"; };
 		DA2B1DF71566B704002FDBD7 /* CPSTAssertionsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CPSTAssertionsTests.m; sourceTree = "<group>"; };
+		DC3E9BEE191DBAC800F6023C /* CPWillFinishDelegateTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CPWillFinishDelegateTest.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -462,6 +464,7 @@
 				1FA68DA314DE9D3D005519B9 /* CPTestErrorHandlingDelegate.h */,
 				1FA68DA414DE9D3D005519B9 /* CPTestErrorHandlingDelegate.m */,
 				5419721C188F9A54004240B4 /* CPRegexpRecogniserTest.m */,
+				DC3E9BEE191DBAC800F6023C /* CPWillFinishDelegateTest.m */,
 				1F9F839F13B731F3006E939D /* Expression.h */,
 				1F9F83A013B731F3006E939D /* Expression.m */,
 				1F9F83A413B732AC006E939D /* Term.h */,
@@ -966,6 +969,7 @@
 				1FA798261567DC58003AC8AE /* CPTestMapCSSTokenisingDelegate.m in Sources */,
 				1FA798271567DC5C003AC8AE /* CPTestErrorHandlingDelegate.m in Sources */,
 				1FA43871162F515C00B92704 /* Expression2.m in Sources */,
+				DC3E9BEF191DBAC800F6023C /* CPWillFinishDelegateTest.m in Sources */,
 				5419721D188F9A54004240B4 /* CPRegexpRecogniserTest.m in Sources */,
 				1FA43872162F515C00B92704 /* RuleBase.m in Sources */,
 				1FA43873162F515C00B92704 /* Term2.m in Sources */,

--- a/CoreParse/Tokenisation/CPTokeniser.h
+++ b/CoreParse/Tokenisation/CPTokeniser.h
@@ -70,6 +70,17 @@
  */
 - (NSUInteger)tokeniser:(CPTokeniser *)tokeniser didNotFindTokenOnInput:(NSString *)input position:(NSUInteger)position error:(NSString **)errorMessage;
 
+/**
+ * This method is called when the tokeniser has finished tokenising and is about to push the
+ * <EOF> token onto the token stream. This gives the delegate a chance to push additional tokens
+ * (such as scope closing tokens in a python tokeniser) onto the token stream before the <EOF>
+ * token is pushed onto the stream.
+ *
+ * @param tokeniser The CPTokeniser that is finishing
+ * @param stream the CPTokenStream any tokens should be pushed onto (if required).
+ */
+- (void)tokeniserWillFinish:(CPTokeniser *)tokeniser stream:(CPTokenStream *)stream;
+
 @end
 
 /**

--- a/CoreParse/Tokenisation/CPTokeniser.m
+++ b/CoreParse/Tokenisation/CPTokeniser.m
@@ -17,6 +17,7 @@ typedef struct
     unsigned int requestsPush:1;
     unsigned int willProduceToken:1;
     unsigned int didNotFindTokenOnInputPositionError:1;
+    unsigned int willFinish:1;
     
 } CPTokeniserDelegateResponseCache;
 
@@ -183,6 +184,11 @@ typedef struct
     }
     if (inputLength <= currentTokenOffset)
     {
+        if (delegateRespondsTo.willFinish)
+        {
+            [delegate tokeniserWillFinish:self stream:stream];
+        }
+
         CPEOFToken *token = [CPEOFToken eof];
         [token setLineNumber:currentLineNumber];
         [token setColumnNumber:currentColumnNumber];
@@ -251,6 +257,7 @@ static CFCharacterSetRef newlineCharset = nil;
         delegateRespondsTo.requestsPush = [delegate respondsToSelector:@selector(tokeniser:requestsToken:pushedOntoStream:)];
         delegateRespondsTo.willProduceToken = [delegate respondsToSelector:@selector(tokeniser:willProduceToken:)];
         delegateRespondsTo.didNotFindTokenOnInputPositionError = [delegate respondsToSelector:@selector(tokeniser:didNotFindTokenOnInput:position:error:)];
+        delegateRespondsTo.willFinish = [delegate respondsToSelector:@selector(tokeniserWillFinish:stream:)];
     }
 }
 

--- a/CoreParseTests/CPWillFinishDelegateTest.m
+++ b/CoreParseTests/CPWillFinishDelegateTest.m
@@ -1,0 +1,54 @@
+//
+//  CPRegexpRecogniserTest.m
+//  CoreParse
+//
+//  Created by Francis Chong on 1/22/14.
+//  Copyright (c) 2014 In The Beginning... All rights reserved.
+//
+
+#import <SenTestingKit/SenTestingKit.h>
+#import "CPTokeniser.h"
+#import "CPKeywordRecogniser.h"
+#import "CPKeywordToken.h"
+#import "CPEOFToken.h"
+
+@interface CPWillFinishDelegateTest : SenTestCase <CPTokeniserDelegate>
+
+@end
+
+@implementation CPWillFinishDelegateTest
+
+- (void)setUp
+{
+    [super setUp];
+    // Put setup code here; it will be run once, before the first test case.
+}
+
+- (void)tearDown
+{
+    // Put teardown code here; it will be run once, after the last test case.
+    [super tearDown];
+}
+
+- (void)testWillFinishCalled
+{
+	CPTokeniser *tokeniser = [[[CPTokeniser alloc] init] autorelease];
+	tokeniser.delegate = self;
+    [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@"{"]];
+    [tokeniser addTokenRecogniser:[CPKeywordRecogniser recogniserForKeyword:@"}"]];
+    CPTokenStream *tokenStream = [tokeniser tokenise:@"{}"];
+    CPTokenStream *expectedTokenStream = [CPTokenStream tokenStreamWithTokens:[NSArray arrayWithObjects:[CPKeywordToken tokenWithKeyword:@"{"], [CPKeywordToken tokenWithKeyword:@"}"], [CPKeywordToken tokenWithKeyword:@"done"], [CPEOFToken eof], nil]];
+    STAssertEqualObjects(tokenStream, expectedTokenStream, @"tokeniser:WillFinish:stream not called", nil);
+}
+
+- (BOOL)tokeniser:(CPTokeniser *)tokeniser shouldConsumeToken:(CPToken *)token
+{
+	return YES;
+}
+
+- (void)tokeniserWillFinish:(CPTokeniser *)tokeniser stream:(CPTokenStream *)stream
+{
+	[stream pushToken:[CPKeywordToken tokenWithKeyword:@"done"]];
+}
+
+@end


### PR DESCRIPTION
This was added to support languages like Python that use indentation to create scopes. For these you need to be able to close the last scopes when the input ends.
