### PR TITLE
A new feature; gitignore added; error fixed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+CoreParse.xcodeproj/project.xcworkspace/xcshareddata/
+CoreParse.xcodeproj/project.xcworkspace/xcuserdata/
+CoreParse.xcodeproj/xcuserdata/

--- a/CoreParse/Grammar/CPGrammar.m
+++ b/CoreParse/Grammar/CPGrammar.m
@@ -444,7 +444,7 @@
 
 - (NSUInteger)hash
 {
-    return [[self start] hash] << 16 + [[self rules] hash];
+    return ([[self start] hash] << 16) + [[self rules] hash];
 }
 
 - (BOOL)isGrammar

--- a/CoreParse/Grammar/CPRHSItem.m
+++ b/CoreParse/Grammar/CPRHSItem.m
@@ -23,7 +23,7 @@
 
 - (NSUInteger)hash
 {
-    return [[self alternatives] hash] << 2 + ([self repeats] ? 0x2 : 0x0) + ([self mayNotExist] ? 0x1 : 0x0);
+    return ([[self alternatives] hash] << 2) + ([self repeats] ? 0x2 : 0x0) + ([self mayNotExist] ? 0x1 : 0x0);
 }
 
 - (BOOL)isRHSItem

--- a/CoreParse/Grammar/CPRule.m
+++ b/CoreParse/Grammar/CPRule.m
@@ -134,7 +134,7 @@
 
 - (NSUInteger)hash
 {
-    return [name hash] << 16 + [self tag] ;
+    return ([name hash] << 16) + [self tag] ;
 }
 
 - (BOOL)isRule

--- a/CoreParse/Parsers/CPShiftReduceParsers/CPLR1Item.m
+++ b/CoreParse/Parsers/CPShiftReduceParsers/CPLR1Item.m
@@ -66,7 +66,7 @@
 
 - (NSUInteger)hash
 {
-    return [[self rule] hash] << 16 + [terminal hash] + [self position];
+    return ([[self rule] hash] << 16) + [terminal hash] + [self position];
 }
 
 - (NSString *)description

--- a/CoreParse/Tokenisation/Token Recognisers/CPQuotedRecogniser.h
+++ b/CoreParse/Tokenisation/Token Recognisers/CPQuotedRecogniser.h
@@ -108,6 +108,13 @@
 @property (readwrite,copy) NSString *escapeSequence;
 
 /**
+ * If `YES`, quoted string will contains `escapeSequence`.
+ * If `NO`, quoted string will not contains `escapeSequence`.
+ * Default is `NO`.
+ */
+@property (nonatomic, assign) BOOL shouldQuoteEscapeSequence;
+
+/**
  * Determines how much of the input string to consume when an escaped literal is found, and what to replace it with.
  */
 @property (readwrite,copy) NSString *(^escapeReplacer)(NSString *tokenStream, NSUInteger *quotePosition);

--- a/CoreParse/Tokenisation/Token Recognisers/CPQuotedRecogniser.m
+++ b/CoreParse/Tokenisation/Token Recognisers/CPQuotedRecogniser.m
@@ -142,7 +142,9 @@
             else
             {
                 NSUInteger quotedPosition = escapeRange.location + escapeRange.length;
-                CFStringRef substr = CFStringCreateWithSubstring(kCFAllocatorDefault, (CFStringRef)tokenString, CFRangeMake(searchRange.location, escapeRange.location - searchRange.location));
+                CFRange subStrRange = CFRangeMake(searchRange.location,
+                                                  escapeRange.location + (self.shouldQuoteEscapeSequence ? escapeRange.length : 0) - searchRange.location);
+                CFStringRef substr = CFStringCreateWithSubstring(kCFAllocatorDefault, (CFStringRef)tokenString, subStrRange);
                 CFStringAppend(outputString, substr);
                 CFRelease(substr);
                 BOOL appended = NO;


### PR DESCRIPTION
1. A new feature about easily parse c string with line breaks;
2. gitignore added;
3. hash error in Xcode 7 fixed (and I think the old hash code was a bug).