### PR TITLE
Add Carthage-compliant framework target, for iOS 10

### DIFF
--- a/CoreParse.xcodeproj/project.pbxproj
+++ b/CoreParse.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		1F0E88FA130462F300537D04 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F0E88F9130462F300537D04 /* Cocoa.framework */; };
+		1B99B1F51D765F6500ED8C1B /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1B99B1F41D765F6500ED8C1B /* CoreFoundation.framework */; };
 		1F0E8904130462F300537D04 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 1F0E8902130462F300537D04 /* InfoPlist.strings */; };
 		1F0E8935130463D000537D04 /* CoreParse.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F0E8934130463D000537D04 /* CoreParse.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1F0E8939130463E900537D04 /* CPTokeniser.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F0E8937130463E900537D04 /* CPTokeniser.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -167,7 +167,7 @@
 		3A60764D1B75D41900204D16 /* RuleBase.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FA4386E162F515C00B92704 /* RuleBase.m */; };
 		3A60764E1B75D41900204D16 /* Term2.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FA43870162F515C00B92704 /* Term2.m */; };
 		3A60764F1B75D62C00204D16 /* CoreParseTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F0E8919130462F300537D04 /* CoreParseTests.m */; };
-		54197209188F7D49004240B4 /* CPRegexpRecogniser.h in Headers */ = {isa = PBXBuildFile; fileRef = 54197207188F7D49004240B4 /* CPRegexpRecogniser.h */; };
+		54197209188F7D49004240B4 /* CPRegexpRecogniser.h in Headers */ = {isa = PBXBuildFile; fileRef = 54197207188F7D49004240B4 /* CPRegexpRecogniser.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5419720A188F7D49004240B4 /* CPRegexpRecogniser.h in Headers */ = {isa = PBXBuildFile; fileRef = 54197207188F7D49004240B4 /* CPRegexpRecogniser.h */; };
 		5419720B188F7D49004240B4 /* CPRegexpRecogniser.m in Sources */ = {isa = PBXBuildFile; fileRef = 54197208188F7D49004240B4 /* CPRegexpRecogniser.m */; };
 		5419720D188F7D49004240B4 /* CPRegexpRecogniser.m in Sources */ = {isa = PBXBuildFile; fileRef = 54197208188F7D49004240B4 /* CPRegexpRecogniser.m */; };
@@ -191,6 +191,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1B99B1F41D765F6500ED8C1B /* CoreFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreFoundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.0.sdk/System/Library/Frameworks/CoreFoundation.framework; sourceTree = DEVELOPER_DIR; };
 		1F0E88F6130462F300537D04 /* CoreParse.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CoreParse.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1F0E88F9130462F300537D04 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
 		1F0E88FC130462F300537D04 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
@@ -326,7 +327,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1F0E88FA130462F300537D04 /* Cocoa.framework in Frameworks */,
+				1B99B1F51D765F6500ED8C1B /* CoreFoundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -383,6 +384,7 @@
 		1F0E88F8130462F300537D04 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				1B99B1F41D765F6500ED8C1B /* CoreFoundation.framework */,
 				1F0E88F9130462F300537D04 /* Cocoa.framework */,
 				1FE77D551375AE6F00879A41 /* Foundation.framework */,
 				1F92818D145C11050033BC34 /* SenTestingKit.framework */,
@@ -1148,7 +1150,10 @@
 				INSTALL_PATH = "@rpath";
 				OTHER_CFLAGS = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos10.0;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				TEST_AFTER_BUILD = YES;
+				VALID_ARCHS = "$(ARCHS_STANDARD)";
 				WRAPPER_EXTENSION = framework;
 			};
 			name = Debug;
@@ -1185,7 +1190,10 @@
 				INSTALL_PATH = "@rpath";
 				OTHER_CFLAGS = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos10.0;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				TEST_AFTER_BUILD = YES;
+				VALID_ARCHS = "$(ARCHS_STANDARD)";
 				WRAPPER_EXTENSION = framework;
 			};
 			name = Release;

--- a/CoreParse.xcodeproj/project.pbxproj
+++ b/CoreParse.xcodeproj/project.pbxproj
@@ -8,6 +8,98 @@
 
 /* Begin PBXBuildFile section */
 		1B99B1F51D765F6500ED8C1B /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1B99B1F41D765F6500ED8C1B /* CoreFoundation.framework */; };
+		1BF63D701D76965900922911 /* CoreParseIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 1BF63D6E1D76965900922911 /* CoreParseIOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1BF63D741D76967200922911 /* CoreParse.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F0E8934130463D000537D04 /* CoreParse.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1BF63D751D76968400922911 /* CPTokeniser.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F0E8937130463E900537D04 /* CPTokeniser.h */; };
+		1BF63D761D76968400922911 /* CPTokenStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F0E8941130466CF00537D04 /* CPTokenStream.h */; };
+		1BF63D771D7696A300922911 /* CPTokenRecogniser.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F4683881306AA8500407491 /* CPTokenRecogniser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1BF63D781D7696A300922911 /* CPKeywordRecogniser.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F4683861306AA8500407491 /* CPKeywordRecogniser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1BF63D791D7696A300922911 /* CPNumberRecogniser.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F4683941306BF6200407491 /* CPNumberRecogniser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1BF63D7A1D7696A300922911 /* CPWhiteSpaceRecogniser.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F4683A01306D66300407491 /* CPWhiteSpaceRecogniser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1BF63D7B1D7696A300922911 /* CPIdentifierRecogniser.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F1DFCDF1306E3C300B22855 /* CPIdentifierRecogniser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1BF63D7C1D7696A300922911 /* CPQuotedRecogniser.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F1DFCF11307D2C500B22855 /* CPQuotedRecogniser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1BF63D7D1D7696A300922911 /* CPRegexpRecogniser.h in Headers */ = {isa = PBXBuildFile; fileRef = 54197207188F7D49004240B4 /* CPRegexpRecogniser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1BF63D7E1D7696B600922911 /* CPToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F0E894A1306795500537D04 /* CPToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1BF63D7F1D7696B600922911 /* CPEOFToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F4683901306B71C00407491 /* CPEOFToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1BF63D801D7696B600922911 /* CPErrorToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FA68D9E14DE98C4005519B9 /* CPErrorToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1BF63D811D7696B600922911 /* CPKeywordToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F46838C1306B45400407491 /* CPKeywordToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1BF63D821D7696B600922911 /* CPNumberToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F4683981306C22800407491 /* CPNumberToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1BF63D831D7696B600922911 /* CPWhiteSpaceToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F4683A41306D7CB00407491 /* CPWhiteSpaceToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1BF63D841D7696B600922911 /* CPIdentifierToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F1DFCE31306E8E800B22855 /* CPIdentifierToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1BF63D851D7696B600922911 /* CPQuotedToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F1DFCED1307D18900B22855 /* CPQuotedToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1BF63D861D7696C800922911 /* CPGrammar.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F50A93C1308604A00C50D7D /* CPGrammar.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1BF63D871D7696D900922911 /* CPGrammarPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FC1827B139ADC800027F597 /* CPGrammarPrivate.h */; };
+		1BF63D881D7696D900922911 /* CPGrammarInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FC18280139AE3800027F597 /* CPGrammarInternal.h */; };
+		1BF63D891D7696D900922911 /* CPRule+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FA866B515DFAEBB005350EE /* CPRule+Internal.h */; };
+		1BF63D8A1D7696E800922911 /* CPRule.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F530B8F1322813E00F52EB5 /* CPRule.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1BF63D8B1D7696E800922911 /* CPGrammarSymbol.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FB3EB38132D096700ACC453 /* CPGrammarSymbol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1BF63D8C1D7696FA00922911 /* CPRHSItem+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FA866BE15E18F67005350EE /* CPRHSItem+Private.h */; };
+		1BF63D8D1D7696FA00922911 /* CPRHSItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F9F83AA13B7CAB9006E939D /* CPRHSItem.h */; };
+		1BF63D8E1D7696FA00922911 /* CPRHSItemResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FC00D4E14544EDC00DC8D35 /* CPRHSItemResult.h */; };
+		1BF63D8F1D76970300922911 /* CPSyntaxTree.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F530B8513216A1A00F52EB5 /* CPSyntaxTree.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1BF63D901D76970F00922911 /* CPParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F530B7C13215A6F00F52EB5 /* CPParser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1BF63D911D76973100922911 /* CPShiftReduceAction.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F3881DF1322ADC9000C8876 /* CPShiftReduceAction.h */; };
+		1BF63D921D76973100922911 /* CPShiftReduceState.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F3881E31322AEE8000C8876 /* CPShiftReduceState.h */; };
+		1BF63D931D76973100922911 /* CPShiftReduceActionTable.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F3881EB1322B669000C8876 /* CPShiftReduceActionTable.h */; };
+		1BF63D941D76973100922911 /* CPShiftReduceGotoTable.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F3881EF1322B69E000C8876 /* CPShiftReduceGotoTable.h */; };
+		1BF63D951D76973100922911 /* CPItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F3882071323F75E000C8876 /* CPItem.h */; };
+		1BF63D961D76973100922911 /* CPLR1Item.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FB3EB2E132BB30300ACC453 /* CPLR1Item.h */; };
+		1BF63D971D76973100922911 /* CPShiftReduceParserProtectedMethods.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F3882031323DDD6000C8876 /* CPShiftReduceParserProtectedMethods.h */; };
+		1BF63D981D76973A00922911 /* CPShiftReduceParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F3881DA1322ACE7000C8876 /* CPShiftReduceParser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1BF63D991D76973A00922911 /* CPSLRParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F3881FF1323DB49000C8876 /* CPSLRParser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1BF63D9A1D76973A00922911 /* CPLR1Parser.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FB3EB2A132BB2E600ACC453 /* CPLR1Parser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1BF63D9B1D76973A00922911 /* CPLALR1Parser.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F6D448E1348CC9500E982C7 /* CPLALR1Parser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1BF63D9C1D76974600922911 /* CPRecoveryAction.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F893A1D14DEEBFC00316FF7 /* CPRecoveryAction.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1BF63D9D1D76974D00922911 /* CPJSONParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F45A2E213422E1300092D78 /* CPJSONParser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1BF63D9E1D76975A00922911 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 1F0E8902130462F300537D04 /* InfoPlist.strings */; };
+		1BF63D9F1D76976900922911 /* NSSetFunctional.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F38820B132432A1000C8876 /* NSSetFunctional.h */; };
+		1BF63DA01D76976900922911 /* NSArray+Functional.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FA6430515E2C5130004FCD3 /* NSArray+Functional.h */; };
+		1BF63DA31D76981200922911 /* CPTokeniser.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F0E8938130463E900537D04 /* CPTokeniser.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		1BF63DA51D76981200922911 /* CPTokenStream.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F0E8942130466D000537D04 /* CPTokenStream.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		1BF63DA81D76981200922911 /* CPKeywordRecogniser.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F4683871306AA8500407491 /* CPKeywordRecogniser.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		1BF63DAA1D76981200922911 /* CPNumberRecogniser.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F4683951306BF6300407491 /* CPNumberRecogniser.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		1BF63DAC1D76981200922911 /* CPWhiteSpaceRecogniser.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F4683A11306D66500407491 /* CPWhiteSpaceRecogniser.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		1BF63DAE1D76981200922911 /* CPIdentifierRecogniser.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F1DFCE01306E3C300B22855 /* CPIdentifierRecogniser.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		1BF63DB01D76981200922911 /* CPQuotedRecogniser.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F1DFCF21307D2C500B22855 /* CPQuotedRecogniser.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		1BF63DB21D76981200922911 /* CPRegexpRecogniser.m in Sources */ = {isa = PBXBuildFile; fileRef = 54197208188F7D49004240B4 /* CPRegexpRecogniser.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		1BF63DB41D76981200922911 /* CPToken.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F0E894B1306795600537D04 /* CPToken.m */; };
+		1BF63DB61D76981200922911 /* CPEOFToken.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F4683911306B71D00407491 /* CPEOFToken.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		1BF63DB81D76981200922911 /* CPErrorToken.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FA68D9F14DE98C4005519B9 /* CPErrorToken.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		1BF63DBA1D76981200922911 /* CPKeywordToken.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F46838D1306B45500407491 /* CPKeywordToken.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		1BF63DBC1D76981200922911 /* CPNumberToken.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F4683991306C22900407491 /* CPNumberToken.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		1BF63DBE1D76981200922911 /* CPWhiteSpaceToken.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F4683A51306D7CF00407491 /* CPWhiteSpaceToken.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		1BF63DC01D76981200922911 /* CPIdentifierToken.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F1DFCE41306E8E900B22855 /* CPIdentifierToken.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		1BF63DC21D76981200922911 /* CPQuotedToken.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F1DFCEE1307D18900B22855 /* CPQuotedToken.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		1BF63DC41D76981200922911 /* CPGrammar.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F50A93D1308604A00C50D7D /* CPGrammar.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		1BF63DC61D76981200922911 /* CPGrammarPrivate.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FC1827C139ADC800027F597 /* CPGrammarPrivate.m */; };
+		1BF63DC81D76981200922911 /* CPGrammarInternal.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FC18281139AE3810027F597 /* CPGrammarInternal.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		1BF63DCA1D76981200922911 /* CPRule.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F530B901322813F00F52EB5 /* CPRule.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		1BF63DCD1D76981200922911 /* CPGrammarSymbol.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FB3EB39132D096800ACC453 /* CPGrammarSymbol.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		1BF63DD01D76981200922911 /* CPRHSItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F9F83AB13B7CABA006E939D /* CPRHSItem.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		1BF63DD21D76981200922911 /* CPRHSItemResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FC00D4F14544EDC00DC8D35 /* CPRHSItemResult.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		1BF63DD41D76981200922911 /* CPSyntaxTree.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F530B8613216A1A00F52EB5 /* CPSyntaxTree.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		1BF63DD61D76981200922911 /* CPParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F530B7D13215A6F00F52EB5 /* CPParser.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		1BF63DD81D76981200922911 /* CPShiftReduceAction.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F3881E01322ADC9000C8876 /* CPShiftReduceAction.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		1BF63DDA1D76981200922911 /* CPShiftReduceState.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F3881E41322AEE8000C8876 /* CPShiftReduceState.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		1BF63DDC1D76981200922911 /* CPShiftReduceActionTable.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F3881EC1322B669000C8876 /* CPShiftReduceActionTable.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		1BF63DDE1D76981200922911 /* CPShiftReduceGotoTable.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F3881F01322B6A0000C8876 /* CPShiftReduceGotoTable.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		1BF63DE01D76981200922911 /* CPItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F3882081323F75F000C8876 /* CPItem.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		1BF63DE21D76981200922911 /* CPLR1Item.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FB3EB2F132BB30A00ACC453 /* CPLR1Item.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		1BF63DE51D76981200922911 /* CPShiftReduceParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F3881DB1322ACE7000C8876 /* CPShiftReduceParser.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		1BF63DE71D76981200922911 /* CPSLRParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F3882001323DB49000C8876 /* CPSLRParser.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		1BF63DE91D76981200922911 /* CPLR1Parser.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FB3EB2B132BB2ED00ACC453 /* CPLR1Parser.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		1BF63DEB1D76981200922911 /* CPLALR1Parser.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F6D448F1348CC9500E982C7 /* CPLALR1Parser.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		1BF63DED1D76981200922911 /* CPRecoveryAction.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F893A1E14DEEBFC00316FF7 /* CPRecoveryAction.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		1BF63DEF1D76981200922911 /* CPJSONParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F45A2E313422E1300092D78 /* CPJSONParser.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		1BF63DF41D76981200922911 /* NSSetFunctional.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F38820C132432AA000C8876 /* NSSetFunctional.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		1BF63DF61D76981200922911 /* NSArray+Functional.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FA6430615E2C5130004FCD3 /* NSArray+Functional.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		1BF63E121D7698DA00922911 /* CPTestEvaluatorDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FB3EB22132BA02C00ACC453 /* CPTestEvaluatorDelegate.h */; };
+		1BF63E131D7698DA00922911 /* CPTestErrorEvaluatorDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F893A2114DEF40D00316FF7 /* CPTestErrorEvaluatorDelegate.h */; };
+		1BF63E141D7698DA00922911 /* CPTestWhiteSpaceIgnoringDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FB81320132FEDAF0095982D /* CPTestWhiteSpaceIgnoringDelegate.h */; };
+		1BF63E151D7698DA00922911 /* CPTestMapCSSTokenisingDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FB81324132FF16E0095982D /* CPTestMapCSSTokenisingDelegate.h */; };
+		1BF63E161D7698DA00922911 /* CPTestErrorHandlingDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FA68DA314DE9D3D005519B9 /* CPTestErrorHandlingDelegate.h */; };
+		1BF63E171D7698DA00922911 /* Expression.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F9F839F13B731F3006E939D /* Expression.h */; };
+		1BF63E181D7698DA00922911 /* Term.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F9F83A413B732AC006E939D /* Term.h */; };
 		1F0E8904130462F300537D04 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 1F0E8902130462F300537D04 /* InfoPlist.strings */; };
 		1F0E8935130463D000537D04 /* CoreParse.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F0E8934130463D000537D04 /* CoreParse.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1F0E8939130463E900537D04 /* CPTokeniser.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F0E8937130463E900537D04 /* CPTokeniser.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -192,6 +284,9 @@
 
 /* Begin PBXFileReference section */
 		1B99B1F41D765F6500ED8C1B /* CoreFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreFoundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.0.sdk/System/Library/Frameworks/CoreFoundation.framework; sourceTree = DEVELOPER_DIR; };
+		1BF63D6C1D76965700922911 /* CoreParseIOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CoreParseIOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		1BF63D6E1D76965900922911 /* CoreParseIOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreParseIOS.h; sourceTree = "<group>"; };
+		1BF63D6F1D76965900922911 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		1F0E88F6130462F300537D04 /* CoreParse.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CoreParse.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1F0E88F9130462F300537D04 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
 		1F0E88FC130462F300537D04 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
@@ -323,6 +418,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		1BF63D681D76965700922911 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		1F0E88F2130462F300537D04 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -358,12 +460,22 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		1BF63D6D1D76965900922911 /* CoreParseIOS */ = {
+			isa = PBXGroup;
+			children = (
+				1BF63D6E1D76965900922911 /* CoreParseIOS.h */,
+				1BF63D6F1D76965900922911 /* Info.plist */,
+			);
+			path = CoreParseIOS;
+			sourceTree = "<group>";
+		};
 		1F0E88EA130462F300537D04 = {
 			isa = PBXGroup;
 			children = (
 				1FC18284139BA4460027F597 /* CompanionGuides */,
 				1F0E88FF130462F300537D04 /* CoreParse */,
 				1F0E8910130462F300537D04 /* CoreParseTests */,
+				1BF63D6D1D76965900922911 /* CoreParseIOS */,
 				1F0E88F8130462F300537D04 /* Frameworks */,
 				1F0E88F7130462F300537D04 /* Products */,
 			);
@@ -377,6 +489,7 @@
 				1F92817F145C11050033BC34 /* libCoreParse.a */,
 				3A60761A1B75D3D400204D16 /* CoreParseTests.xctest */,
 				3A6076291B75D3EA00204D16 /* iOSCoreParseTests.xctest */,
+				1BF63D6C1D76965700922911 /* CoreParseIOS.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -632,6 +745,65 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		1BF63D691D76965700922911 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1BF63E181D7698DA00922911 /* Term.h in Headers */,
+				1BF63D8C1D7696FA00922911 /* CPRHSItem+Private.h in Headers */,
+				1BF63D811D7696B600922911 /* CPKeywordToken.h in Headers */,
+				1BF63D901D76970F00922911 /* CPParser.h in Headers */,
+				1BF63D7B1D7696A300922911 /* CPIdentifierRecogniser.h in Headers */,
+				1BF63D821D7696B600922911 /* CPNumberToken.h in Headers */,
+				1BF63D891D7696D900922911 /* CPRule+Internal.h in Headers */,
+				1BF63D8F1D76970300922911 /* CPSyntaxTree.h in Headers */,
+				1BF63D791D7696A300922911 /* CPNumberRecogniser.h in Headers */,
+				1BF63D7D1D7696A300922911 /* CPRegexpRecogniser.h in Headers */,
+				1BF63D991D76973A00922911 /* CPSLRParser.h in Headers */,
+				1BF63D871D7696D900922911 /* CPGrammarPrivate.h in Headers */,
+				1BF63D9F1D76976900922911 /* NSSetFunctional.h in Headers */,
+				1BF63E161D7698DA00922911 /* CPTestErrorHandlingDelegate.h in Headers */,
+				1BF63D8B1D7696E800922911 /* CPGrammarSymbol.h in Headers */,
+				1BF63D701D76965900922911 /* CoreParseIOS.h in Headers */,
+				1BF63D841D7696B600922911 /* CPIdentifierToken.h in Headers */,
+				1BF63D9D1D76974D00922911 /* CPJSONParser.h in Headers */,
+				1BF63E141D7698DA00922911 /* CPTestWhiteSpaceIgnoringDelegate.h in Headers */,
+				1BF63DA01D76976900922911 /* NSArray+Functional.h in Headers */,
+				1BF63D9C1D76974600922911 /* CPRecoveryAction.h in Headers */,
+				1BF63D761D76968400922911 /* CPTokenStream.h in Headers */,
+				1BF63D851D7696B600922911 /* CPQuotedToken.h in Headers */,
+				1BF63E151D7698DA00922911 /* CPTestMapCSSTokenisingDelegate.h in Headers */,
+				1BF63D981D76973A00922911 /* CPShiftReduceParser.h in Headers */,
+				1BF63D741D76967200922911 /* CoreParse.h in Headers */,
+				1BF63D771D7696A300922911 /* CPTokenRecogniser.h in Headers */,
+				1BF63E171D7698DA00922911 /* Expression.h in Headers */,
+				1BF63D781D7696A300922911 /* CPKeywordRecogniser.h in Headers */,
+				1BF63D751D76968400922911 /* CPTokeniser.h in Headers */,
+				1BF63D7C1D7696A300922911 /* CPQuotedRecogniser.h in Headers */,
+				1BF63D931D76973100922911 /* CPShiftReduceActionTable.h in Headers */,
+				1BF63D921D76973100922911 /* CPShiftReduceState.h in Headers */,
+				1BF63D7A1D7696A300922911 /* CPWhiteSpaceRecogniser.h in Headers */,
+				1BF63D8A1D7696E800922911 /* CPRule.h in Headers */,
+				1BF63D9A1D76973A00922911 /* CPLR1Parser.h in Headers */,
+				1BF63D971D76973100922911 /* CPShiftReduceParserProtectedMethods.h in Headers */,
+				1BF63D911D76973100922911 /* CPShiftReduceAction.h in Headers */,
+				1BF63D881D7696D900922911 /* CPGrammarInternal.h in Headers */,
+				1BF63D8E1D7696FA00922911 /* CPRHSItemResult.h in Headers */,
+				1BF63D861D7696C800922911 /* CPGrammar.h in Headers */,
+				1BF63D941D76973100922911 /* CPShiftReduceGotoTable.h in Headers */,
+				1BF63D9B1D76973A00922911 /* CPLALR1Parser.h in Headers */,
+				1BF63D7E1D7696B600922911 /* CPToken.h in Headers */,
+				1BF63D961D76973100922911 /* CPLR1Item.h in Headers */,
+				1BF63D8D1D7696FA00922911 /* CPRHSItem.h in Headers */,
+				1BF63D831D7696B600922911 /* CPWhiteSpaceToken.h in Headers */,
+				1BF63E121D7698DA00922911 /* CPTestEvaluatorDelegate.h in Headers */,
+				1BF63D801D7696B600922911 /* CPErrorToken.h in Headers */,
+				1BF63D7F1D7696B600922911 /* CPEOFToken.h in Headers */,
+				1BF63D951D76973100922911 /* CPItem.h in Headers */,
+				1BF63E131D7698DA00922911 /* CPTestErrorEvaluatorDelegate.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		1F0E88F3130462F300537D04 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -701,6 +873,24 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		1BF63D6B1D76965700922911 /* CoreParseIOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1BF63D731D76965900922911 /* Build configuration list for PBXNativeTarget "CoreParseIOS" */;
+			buildPhases = (
+				1BF63D671D76965700922911 /* Sources */,
+				1BF63D681D76965700922911 /* Frameworks */,
+				1BF63D691D76965700922911 /* Headers */,
+				1BF63D6A1D76965700922911 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = CoreParseIOS;
+			productName = CoreParseIOS;
+			productReference = 1BF63D6C1D76965700922911 /* CoreParseIOS.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		1F0E88F5130462F300537D04 /* CoreParse */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 1F0E891D130462F300537D04 /* Build configuration list for PBXNativeTarget "CoreParse" */;
@@ -796,6 +986,11 @@
 				LastUpgradeCheck = 0460;
 				ORGANIZATIONNAME = "In The Beginning...";
 				TargetAttributes = {
+					1BF63D6B1D76965700922911 = {
+						CreatedOnToolsVersion = 8.0;
+						DevelopmentTeam = 6F9SQVL3N2;
+						ProvisioningStyle = Automatic;
+					};
 					3A6076191B75D3D400204D16 = {
 						CreatedOnToolsVersion = 7.0;
 					};
@@ -821,11 +1016,20 @@
 				1F92817E145C11050033BC34 /* iOSCoreParse */,
 				3A6076191B75D3D400204D16 /* CoreParseTests */,
 				3A6076281B75D3EA00204D16 /* iOSCoreParseTests */,
+				1BF63D6B1D76965700922911 /* CoreParseIOS */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		1BF63D6A1D76965700922911 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1BF63D9E1D76975A00922911 /* InfoPlist.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		1F0E88F4130462F300537D04 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -869,6 +1073,52 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		1BF63D671D76965700922911 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1BF63DA31D76981200922911 /* CPTokeniser.m in Sources */,
+				1BF63DA51D76981200922911 /* CPTokenStream.m in Sources */,
+				1BF63DA81D76981200922911 /* CPKeywordRecogniser.m in Sources */,
+				1BF63DAA1D76981200922911 /* CPNumberRecogniser.m in Sources */,
+				1BF63DAC1D76981200922911 /* CPWhiteSpaceRecogniser.m in Sources */,
+				1BF63DAE1D76981200922911 /* CPIdentifierRecogniser.m in Sources */,
+				1BF63DB01D76981200922911 /* CPQuotedRecogniser.m in Sources */,
+				1BF63DB21D76981200922911 /* CPRegexpRecogniser.m in Sources */,
+				1BF63DB41D76981200922911 /* CPToken.m in Sources */,
+				1BF63DB61D76981200922911 /* CPEOFToken.m in Sources */,
+				1BF63DB81D76981200922911 /* CPErrorToken.m in Sources */,
+				1BF63DBA1D76981200922911 /* CPKeywordToken.m in Sources */,
+				1BF63DBC1D76981200922911 /* CPNumberToken.m in Sources */,
+				1BF63DBE1D76981200922911 /* CPWhiteSpaceToken.m in Sources */,
+				1BF63DC01D76981200922911 /* CPIdentifierToken.m in Sources */,
+				1BF63DC21D76981200922911 /* CPQuotedToken.m in Sources */,
+				1BF63DC41D76981200922911 /* CPGrammar.m in Sources */,
+				1BF63DC61D76981200922911 /* CPGrammarPrivate.m in Sources */,
+				1BF63DC81D76981200922911 /* CPGrammarInternal.m in Sources */,
+				1BF63DCA1D76981200922911 /* CPRule.m in Sources */,
+				1BF63DCD1D76981200922911 /* CPGrammarSymbol.m in Sources */,
+				1BF63DD01D76981200922911 /* CPRHSItem.m in Sources */,
+				1BF63DD21D76981200922911 /* CPRHSItemResult.m in Sources */,
+				1BF63DD41D76981200922911 /* CPSyntaxTree.m in Sources */,
+				1BF63DD61D76981200922911 /* CPParser.m in Sources */,
+				1BF63DD81D76981200922911 /* CPShiftReduceAction.m in Sources */,
+				1BF63DDA1D76981200922911 /* CPShiftReduceState.m in Sources */,
+				1BF63DDC1D76981200922911 /* CPShiftReduceActionTable.m in Sources */,
+				1BF63DDE1D76981200922911 /* CPShiftReduceGotoTable.m in Sources */,
+				1BF63DE01D76981200922911 /* CPItem.m in Sources */,
+				1BF63DE21D76981200922911 /* CPLR1Item.m in Sources */,
+				1BF63DE51D76981200922911 /* CPShiftReduceParser.m in Sources */,
+				1BF63DE71D76981200922911 /* CPSLRParser.m in Sources */,
+				1BF63DE91D76981200922911 /* CPLR1Parser.m in Sources */,
+				1BF63DEB1D76981200922911 /* CPLALR1Parser.m in Sources */,
+				1BF63DED1D76981200922911 /* CPRecoveryAction.m in Sources */,
+				1BF63DEF1D76981200922911 /* CPJSONParser.m in Sources */,
+				1BF63DF41D76981200922911 /* NSSetFunctional.m in Sources */,
+				1BF63DF61D76981200922911 /* NSArray+Functional.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		1F0E88F1130462F300537D04 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1038,6 +1288,110 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		1BF63D711D76965900922911 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = 6F9SQVL3N2;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = CoreParseIOS/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.sstadelman.CoreParseIOS;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALID_ARCHS = "$(ARCHS_STANDARD)";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		1BF63D721D76965900922911 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = 6F9SQVL3N2;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = CoreParseIOS/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = com.sstadelman.CoreParseIOS;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VALID_ARCHS = "$(ARCHS_STANDARD)";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 		1F0E891B130462F300537D04 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1410,6 +1764,14 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		1BF63D731D76965900922911 /* Build configuration list for PBXNativeTarget "CoreParseIOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1BF63D711D76965900922911 /* Debug */,
+				1BF63D721D76965900922911 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
 		1F0E88EF130462F300537D04 /* Build configuration list for PBXProject "CoreParse" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/CoreParse.xcodeproj/xcshareddata/xcschemes/CoreParseIOS.xcscheme
+++ b/CoreParse.xcodeproj/xcshareddata/xcschemes/CoreParseIOS.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0800"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1BF63D6B1D76965700922911"
+               BuildableName = "CoreParseIOS.framework"
+               BlueprintName = "CoreParseIOS"
+               ReferencedContainer = "container:CoreParse.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1BF63D6B1D76965700922911"
+            BuildableName = "CoreParseIOS.framework"
+            BlueprintName = "CoreParseIOS"
+            ReferencedContainer = "container:CoreParse.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1BF63D6B1D76965700922911"
+            BuildableName = "CoreParseIOS.framework"
+            BlueprintName = "CoreParseIOS"
+            ReferencedContainer = "container:CoreParse.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/CoreParseIOS/CoreParseIOS.h
+++ b/CoreParseIOS/CoreParseIOS.h
@@ -1,0 +1,20 @@
+//
+//  CoreParseIOS.h
+//  CoreParseIOS
+//
+//  Created by Stadelman, Stan on 8/30/16.
+//  Copyright © 2016 In The Beginning... All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for CoreParseIOS.
+FOUNDATION_EXPORT double CoreParseIOSVersionNumber;
+
+//! Project version string for CoreParseIOS.
+FOUNDATION_EXPORT const unsigned char CoreParseIOSVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <CoreParseIOS/PublicHeader.h>
+
+
+#import <CoreParseIOS/CoreParse.h>

--- a/CoreParseIOS/Info.plist
+++ b/CoreParseIOS/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>


### PR DESCRIPTION
I'm a [NUI](https://github.com/tombenner/nui) developer, and am working to update the workflow to support [Carthage](https://github.com/Carthage/Carthage) dependency manager for modern swift applications.  Carthage is dependent on the shared build scheme(s) in the `*.xcodeproj`.  For modern iOS applications, the `*.framework` linkage is preferable to the library approach.

I have not touched any of the existing targets, but instead added a new target, of type:  iOS, objective-c, framework.  iOS 10 SDK, `$(ARCHS_STANDARD)`.

I copied the build phases settings of the MacOS framework target, and added the flag `-fno-objc-arc` to the necessary source `.m` files.

Last, I set the new build scheme for the iOS framework to "shared", and pushed the `xcscheme`, which can be discovered by Carthage dependency manager.

---

To link CoreParse to an iOS application target, using Carthage, the developer should add the following line to their Cartfile:
`github "https://github.com/beelsebob/CoreParse.git" "master"`  (Idealy, a new release could be created, eliminating the need for the branch name)

Then, run `carthage update` from the project root.  This checks out the source of the CoreParse repo, and attempts to build the shared schemes.  The developer should then find the built framework in the `$(SRC_ROOT)/carthage/Build` folder, and drag to the `Linked Frameworks and Libraries` section of the target **General** tab. 

To update in the future, re-run the `carthage update` command.